### PR TITLE
closes #57; all type filters now being added to map correctly

### DIFF
--- a/src/map-interface/map-page/map-view/filter-helpers.ts
+++ b/src/map-interface/map-page/map-view/filter-helpers.ts
@@ -58,7 +58,7 @@ function getRemovedOrNewFilters(nextProps, map) {
     }
   }
   // Otherwise, a filter was added
-  else if (incoming.length) {
+  if (incoming.length > 0) {
     let newFilterString = incoming[0].split("|");
     let filterToApply = nextProps.filters.filter((f) => {
       if (
@@ -72,7 +72,6 @@ function getRemovedOrNewFilters(nextProps, map) {
     if (filterToApply.length === 0) {
       return false;
     }
-
     filterToApply = filterToApply[0];
 
     // Check which kind of filter it is
@@ -138,6 +137,9 @@ function getRemovedOrNewFilters(nextProps, map) {
         break;
 
       case "lithologies":
+      case "all_lithologies":
+      case "all_lithology_types":
+      case "all_lithology_classes":
         map.lithFilters.push(filterToApply.name);
         map.lithFiltersIndex[
           `${filterToApply.category}|${filterToApply.type}|${filterToApply.name}`

--- a/src/map-interface/map-page/map-view/map.ts
+++ b/src/map-interface/map-page/map-view/map.ts
@@ -593,7 +593,9 @@ class Map extends Component<MapProps, {}> {
       }
     }
     // Handle changes to map filters
-    else if (nextProps.filters.length != this.props.filters.length) {
+    else if (
+      JSON.stringify(nextProps.filters) !== JSON.stringify(this.props.filters)
+    ) {
       // If all filters have been removed simply reset the filter states
       if (nextProps.filters.length === 0) {
         this.filters = [];


### PR DESCRIPTION
Solves the bug with `all_` type filters. See #57 