### PR TITLE
Infodraw bug

### DIFF
--- a/src/map-interface/app-state/hooks.ts
+++ b/src/map-interface/app-state/hooks.ts
@@ -4,7 +4,6 @@ import { useStore, useSelector, useDispatch } from "react-redux";
 import { AppState } from ".";
 import React from "react";
 import { useEffect } from "react";
-import { eventNames } from "process";
 
 function useActionDispatch() {
   return useDispatch<React.Dispatch<Action>>();

--- a/src/map-interface/app-state/sections/core/actions.ts
+++ b/src/map-interface/app-state/sections/core/actions.ts
@@ -48,6 +48,7 @@ type RECEIVED_COLUMN_QUERY = {
   data: any;
   column: any;
 };
+type RESET_COLUMN_INFO = { type: "reset-column-info" };
 
 type START_GDD_QUERY = { type: "start-gdd-query"; cancelToken: any };
 type RECEIVED_GDD_QUERY = { type: "received-gdd-query"; data: any };
@@ -93,6 +94,7 @@ type SET_ACTIVE_INDEX_MAP = { type: "set-active-index-map" };
 type UPDATE_STATE = { type: "update-state"; state: any };
 
 export type CoreAction =
+  | RESET_COLUMN_INFO
   | CLEAR_FILTERS
   | SET_INPUT_FOCUS
   | SET_SEARCH_TERM

--- a/src/map-interface/app-state/sections/core/actions.ts
+++ b/src/map-interface/app-state/sections/core/actions.ts
@@ -1,4 +1,4 @@
-import { MapAction, MapState } from "../map";
+import { MapAction, MapLayer, MapState } from "../map";
 import { CancelToken } from "axios";
 export * from "../map";
 
@@ -48,7 +48,11 @@ type RECEIVED_COLUMN_QUERY = {
   data: any;
   column: any;
 };
-type RESET_COLUMN_INFO = { type: "reset-column-info" };
+
+type MAP_LAYERS_CHANGED = {
+  type: "map-layers-changed";
+  mapLayers: Set<MapLayer>;
+};
 
 type START_GDD_QUERY = { type: "start-gdd-query"; cancelToken: any };
 type RECEIVED_GDD_QUERY = { type: "received-gdd-query"; data: any };
@@ -94,7 +98,7 @@ type SET_ACTIVE_INDEX_MAP = { type: "set-active-index-map" };
 type UPDATE_STATE = { type: "update-state"; state: any };
 
 export type CoreAction =
-  | RESET_COLUMN_INFO
+  | MAP_LAYERS_CHANGED
   | CLEAR_FILTERS
   | SET_INPUT_FOCUS
   | SET_SEARCH_TERM

--- a/src/map-interface/app-state/sections/core/index.ts
+++ b/src/map-interface/app-state/sections/core/index.ts
@@ -84,6 +84,16 @@ export function coreReducer(
     case "map-idle":
       if (!state.mapIsLoading) return state;
       return { ...state, mapIsLoading: false };
+    case "map-layers-changed":
+      let columnInfo = state.columnInfo;
+      let pbdbData = state.pbdbData;
+      if (!action.mapLayers.has(MapLayer.COLUMNS)) columnInfo = [];
+      if (!action.mapLayers.has(MapLayer.FOSSILS)) pbdbData = [];
+      return {
+        ...state,
+        columnInfo,
+        pbdbData,
+      };
     case "toggle-menu":
       const shouldOpen = state.inputFocus || !state.menuOpen;
 
@@ -482,8 +492,6 @@ export function coreReducer(
 
     case "reset-pbdb":
       return { ...state, pbdbData: [] };
-    case "reset-column-info":
-      return { ...state, columnInfo: [] };
     case "go-to-place":
       return {
         ...state,

--- a/src/map-interface/app-state/sections/core/index.ts
+++ b/src/map-interface/app-state/sections/core/index.ts
@@ -109,11 +109,8 @@ export function coreReducer(
       return {
         ...state,
         infoDrawerOpen: false,
-        //columnInfo: {},
-        //mapInfo: [],
-        //pbdbData: [],
+        columnInfo: {},
       };
-
     case "expand-infodrawer":
       return { ...state, infoDrawerExpanded: !state.infoDrawerExpanded };
 
@@ -485,6 +482,8 @@ export function coreReducer(
 
     case "reset-pbdb":
       return { ...state, pbdbData: [] };
+    case "reset-column-info":
+      return { ...state, columnInfo: [] };
     case "go-to-place":
       return {
         ...state,

--- a/src/map-interface/map-page/map-view/index.ts
+++ b/src/map-interface/map-page/map-view/index.ts
@@ -133,11 +133,8 @@ function MapContainer(props) {
   useEffect(() => {
     if (mapLayers.has(MapLayer.COLUMNS)) {
       runAction({ type: "get-filtered-columns" });
-    } else if (!mapLayers.has(MapLayer.COLUMNS)) {
-      runAction({ type: "reset-column-info" });
-    } else if (!mapLayers.has(MapLayer.FOSSILS)) {
-      runAction({ type: "reset-pbdb" });
     }
+    runAction({ type: "map-layers-changed", mapLayers });
   }, [filters, mapLayers]);
 
   const timeout = useRef<Timeout>(null);

--- a/src/map-interface/map-page/map-view/index.ts
+++ b/src/map-interface/map-page/map-view/index.ts
@@ -133,6 +133,10 @@ function MapContainer(props) {
   useEffect(() => {
     if (mapLayers.has(MapLayer.COLUMNS)) {
       runAction({ type: "get-filtered-columns" });
+    } else if (!mapLayers.has(MapLayer.COLUMNS)) {
+      runAction({ type: "reset-column-info" });
+    } else if (!mapLayers.has(MapLayer.FOSSILS)) {
+      runAction({ type: "reset-pbdb" });
     }
   }, [filters, mapLayers]);
 

--- a/src/map-interface/map-page/menu.ts
+++ b/src/map-interface/map-page/menu.ts
@@ -23,6 +23,7 @@ import {
   useSearchState,
   MenuPanel,
   MapLayer,
+  MapPosition,
 } from "../app-state";
 import { SearchResults } from "../components/searchbar";
 import classNames from "classnames";
@@ -43,7 +44,46 @@ const ListButton = (props: ListButtonProps) => {
   if (typeof props.icon != "string") {
     icon = h(props.icon, { size: 20 });
   }
-  return h(Button, { ...props, className: "list-button", icon });
+  return h(Button, { ...rest, className: "list-button", icon });
+};
+
+const YourLocationButton = () => {
+  const runAction = useAppActions();
+  const onClick = () => {
+    navigator.geolocation.getCurrentPosition(
+      function (position) {
+        const lngLat = {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        };
+        const mapPosition: MapPosition = {
+          camera: {
+            altitude: 0,
+            bearing: 0,
+            pitch: 0,
+            ...lngLat,
+          },
+          target: {
+            zoom: 6,
+            ...lngLat,
+          },
+        };
+        runAction({
+          type: "map-moved",
+          data: mapPosition,
+        });
+      },
+      (e) => {
+        console.log(e);
+      },
+      { timeout: 100000 }
+    );
+  };
+  return h(
+    ListButton,
+    { icon: "map-marker", onClick, disabled: true },
+    "Your location"
+  );
 };
 
 const MinimalButton = (props) => h(Button, { ...props, minimal: true });
@@ -123,7 +163,7 @@ const LayerList = (props) => {
       }),
     ]),
     h(MenuGroup, [
-      h(ListButton, { disabled: true, icon: "map-marker" }, "Your location"),
+      h(YourLocationButton),
       h(
         ListButton,
         { onClick: toggleElevationChart, icon: ElevationIcon },


### PR DESCRIPTION
Fix for bug recorded in #65. I've added another recducer action that resets columnInfo to an empty array, one already exists for PBDB info. I've added a runAction call for both of these in the useEffect in the Map component and run them when their respective mapLayer is toggled off.

Not an ideal solution, but is the minimal code solution at this time to fix the issue. 