### PR TITLE
Column footprint editor

### DIFF
--- a/packages/column-footprint-editor/.dockerignore
+++ b/packages/column-footprint-editor/.dockerignore
@@ -1,0 +1,6 @@
+.git
+Dockerfile
+package-lock.json
+/node_modules/*
+/dist/*
+/.parcel-cache/*

--- a/packages/column-footprint-editor/.env.example
+++ b/packages/column-footprint-editor/.env.example
@@ -1,0 +1,5 @@
+## .env file must go in the frontend directory
+
+API_BASE=http://geologic_map_api/
+MAPBOX_TOKEN=mapbox_access_token
+## https://docs.mapbox.com/help/getting-started/access-tokens/

--- a/packages/column-footprint-editor/.gitignore
+++ b/packages/column-footprint-editor/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+package-lock.json
+.parcel-cache
+Dockerfile.dev
+dist
+__pychache__

--- a/packages/column-footprint-editor/.parcelrc
+++ b/packages/column-footprint-editor/.parcelrc
@@ -1,0 +1,8 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "jsx:*.svg": [
+      "@parcel/transformer-svg-react"
+    ]
+  }
+}

--- a/packages/column-footprint-editor/Dockerfile
+++ b/packages/column-footprint-editor/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14
+
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+WORKDIR /app/dist
+
+ENTRYPOINT ["npx", "serve", "-p", "1235"]

--- a/packages/column-footprint-editor/package.json
+++ b/packages/column-footprint-editor/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "my-project",
+  "scripts": {
+    "start": "ENV=development parcel serve -p 1235 ./src/index.html",
+    "build": "ENV=production parcel build --public-url /column-topology/ ./src/index.html"
+  },
+  "babel": {
+    "presets": [
+      "@parcel/babel-preset-env",
+      "@babel/preset-react"
+    ],
+    "plugins": [
+      "@parcel/babel-plugin-transform-runtime"
+    ]
+  },
+  "dependencies": {
+    "@blueprintjs/core": "^4.5.1",
+    "@blueprintjs/popover2": "^1.4.1",
+    "@blueprintjs/select": "^4.4.1",
+    "@macrostrat/ui-components": "^2.0.3",
+    "@mapbox/mapbox-gl-draw": "^1.2.2",
+    "@parcel/transformer-svg-react": "^2.6.2",
+    "@turf/nearest-point-on-line": "^5.1.5",
+    "@types/mapbox__mapbox-gl-draw": "^1.2.4",
+    "axios": "^0.21.1",
+    "mapbox-gl": "^2.2.0",
+    "mapbox-gl-draw-snap-mode": "^0.1.6",
+    "react": "^16.13.1",
+    "react-color": "^2.19.3",
+    "react-dom": "^16.13.1",
+    "react-loading-overlay": "^1.0.1",
+    "react-router-dom": "^5.3.0",
+    "topojson-client": "^3.1.0"
+  },
+  "devDependencies": {
+    "@parcel/babel-plugin-transform-runtime": "^2.6.2",
+    "@parcel/transformer-stylus": "^2.0.0-beta.2",
+    "parcel": "^2.6.2",
+    "process": "^0.11.10"
+  }
+}

--- a/packages/column-footprint-editor/src/assets/12-side.svg
+++ b/packages/column-footprint-editor/src/assets/12-side.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="422.94,610.91 290.15,642.1 159.55,602.71 66.14,503.3 34.96,370.51 74.34,239.91 173.75,146.51 
+	306.54,115.32 437.14,154.7 530.55,254.11 561.74,386.9 522.35,517.5 "/>
+</svg>

--- a/packages/column-footprint-editor/src/assets/16-side.svg
+++ b/packages/column-footprint-editor/src/assets/16-side.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="486.49,555.44 403.82,611.94 305.81,632.5 207.4,613.99 123.56,559.23 67.06,476.56 46.5,378.55 
+	65.01,280.14 119.77,196.3 202.44,139.8 300.45,119.24 398.86,137.75 482.7,192.51 539.2,275.18 559.76,373.19 541.25,471.6 "/>
+</svg>

--- a/packages/column-footprint-editor/src/assets/20-side.svg
+++ b/packages/column-footprint-editor/src/assets/20-side.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="472.34,593.43 398.99,637.37 315.66,656.48 230.49,648.91 151.84,615.4 87.39,559.21 43.45,485.86 
+	24.33,402.53 31.9,317.36 65.42,238.71 121.6,174.26 194.95,130.32 278.29,111.2 363.45,118.77 442.11,152.29 506.56,208.47 
+	550.49,281.82 569.61,365.16 562.04,450.32 528.53,528.98 "/>
+</svg>

--- a/packages/column-footprint-editor/src/assets/24-side.svg
+++ b/packages/column-footprint-editor/src/assets/24-side.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="510.19,576.24 449.24,621.91 378.55,650.26 302.93,659.34 227.54,648.54 157.51,618.6 97.61,571.55 
+	51.94,510.6 23.59,439.91 14.51,364.29 25.31,288.9 55.25,218.87 102.3,158.97 163.25,113.3 233.94,84.95 309.56,75.87 
+	384.95,86.67 454.98,116.61 514.88,163.66 560.55,224.61 588.9,295.3 597.98,370.92 587.18,446.31 557.24,516.34 "/>
+</svg>

--- a/packages/column-footprint-editor/src/assets/4-side.svg
+++ b/packages/column-footprint-editor/src/assets/4-side.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<rect x="105.43" y="171.97" transform="matrix(0.6995 -0.7147 0.7147 0.6995 -173.1983 328.0037)" class="st0" width="395.92" height="395.92"/>
+</svg>

--- a/packages/column-footprint-editor/src/assets/8-side.svg
+++ b/packages/column-footprint-editor/src/assets/8-side.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 612 792" style="enable-background:new 0 0 612 792;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#000000;stroke-width:10;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="574.43,487.81 415.12,648.81 188.63,650 27.63,490.69 26.43,264.19 185.74,103.19 412.24,102 
+	573.24,261.31 "/>
+</svg>

--- a/packages/column-footprint-editor/src/components/blueprint/buttons.tsx
+++ b/packages/column-footprint-editor/src/components/blueprint/buttons.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Button } from "@blueprintjs/core";
+import { useAPIResult } from "@macrostrat/ui-components";
+import { base } from "../../context/env";
+
+function SaveButton(props) {
+  const { onClick, minimal, disabled } = props;
+
+  return (
+    <Button
+      intent="primary"
+      minimal={minimal}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      Save
+    </Button>
+  );
+}
+
+function downloadObjectAsJson(exportObj, exportName) {
+  var dataStr = "data:text/csv;charset=utf-8," + encodeURIComponent(exportObj);
+  var downloadAnchorNode = document.createElement("a");
+  downloadAnchorNode.setAttribute("href", dataStr);
+  downloadAnchorNode.setAttribute("download", exportName + ".csv");
+  document.body.appendChild(downloadAnchorNode); // required for firefox
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}
+
+function DownloadButton(props) {
+  const { project_id } = props;
+  let data = [];
+  if (project_id) {
+    data = useAPIResult(base + `${project_id}/csv`);
+  }
+
+  const onClick = () => {
+    downloadObjectAsJson(data, "columns");
+  };
+  return (
+    <Button
+      icon="download"
+      intent="primary"
+      onClick={onClick}
+      minimal={true}
+      disabled={project_id == null}
+    >
+      Download
+    </Button>
+  );
+}
+
+export { SaveButton, DownloadButton };

--- a/packages/column-footprint-editor/src/components/blueprint/dialog.tsx
+++ b/packages/column-footprint-editor/src/components/blueprint/dialog.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from "react";
+import { Overlay, Button, Card } from "@blueprintjs/core";
+import "./main.css";
+
+function OverlayBox(props) {
+  const {
+    open,
+    children,
+    closeOpen,
+    HeaderComponent,
+    className = "overlay",
+    closeButton = true,
+    cardStyles = {},
+  } = props;
+
+  const [state, setState] = useState({ top: 100, left: 20 });
+  const [offset, setOffset] = useState({ rel_x: 0, rel_y: 0 });
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    //setup event listeners
+    if (!dragging) return;
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    return () => {
+      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("mousemove", onMouseMove);
+    };
+  }, [dragging]);
+
+  const onMouseDown = (e) => {
+    if (e.button !== 0) return;
+    setDragging(true);
+    setOffset(getOffest(e));
+  };
+
+  const onMouseUp = (e) => {
+    setDragging(false);
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  const getOffest = (e) => {
+    const rel_x = e.pageX - state.left;
+    const rel_y = e.pageY - state.top;
+    return { rel_x, rel_y };
+  };
+
+  const onMouseMove = (e) => {
+    if (dragging) {
+      const { rel_x, rel_y } = offset;
+      const left_ = e.pageX - rel_x;
+      const top_ = e.pageY - rel_y;
+      setState({ top: top_, left: left_ });
+    }
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  const overlayProperties = {
+    autoFocus: true,
+    canEscapeKeyClose: true,
+    canOutsideClickClose: true,
+    enforceFocus: false,
+    hasBackdrop: false,
+    usePortal: true,
+    useTallContent: false,
+  };
+
+  const style = { top: `${state.top}px`, left: `${state.left}px` };
+
+  return (
+    <Overlay isOpen={open} {...overlayProperties}>
+      <div className={className} style={style}>
+        <Card style={cardStyles}>
+          <HeaderComponent onMouseDown={onMouseDown} />
+          {children}
+          {closeButton ? (
+            <Button intent="danger" onClick={closeOpen}>
+              Close
+            </Button>
+          ) : null}
+        </Card>
+      </div>
+    </Overlay>
+  );
+}
+
+export { OverlayBox };

--- a/packages/column-footprint-editor/src/components/blueprint/index.ts
+++ b/packages/column-footprint-editor/src/components/blueprint/index.ts
@@ -1,0 +1,5 @@
+export * from "./dialog";
+export * from "./navbar";
+export * from "./buttons";
+export * from "./toaster";
+export * from "./select";

--- a/packages/column-footprint-editor/src/components/blueprint/main.css
+++ b/packages/column-footprint-editor/src/components/blueprint/main.css
@@ -1,0 +1,59 @@
+@import "~/node_modules/@blueprintjs/core/lib/css/blueprint.css";
+@import "~/node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css";
+
+.overlay {
+  max-width: 500px;
+}
+
+.drag-bar-top {
+  height: 50px;
+  width: 100%;
+  z-index: 22;
+}
+.projects-drop-down {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  padding: 5px;
+  justify-content: flex-end;
+}
+
+.projects-drop-more {
+  display: flex;
+  flex-direction: column;
+  padding: 5px;
+  justify-content: flex-end;
+}
+
+.nav-contents {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 10px;
+}
+
+.toolbar {
+  max-width: 300px;
+  margin-top: 5px;
+}
+.nav-right,
+.nav-left {
+  display: flex;
+  align-items: center;
+}
+
+.panel-stack {
+  min-height: 500px;
+}
+.main-dialog-header {
+  margin-top: 5px;
+  margin-left: 5px;
+}
+.btn-holder {
+  float: right;
+  margin-top: -23px;
+  margin-right: -20px;
+}
+.project-btns {
+  margin: 0px 5px 10px 0px;
+}

--- a/packages/column-footprint-editor/src/components/blueprint/navbar.tsx
+++ b/packages/column-footprint-editor/src/components/blueprint/navbar.tsx
@@ -1,0 +1,207 @@
+import React, { useContext } from "react";
+import { DownloadButton } from ".";
+import {
+  Button,
+  Navbar,
+  Popover,
+  MenuItem,
+  Menu,
+  MenuDivider,
+  Icon,
+  IconName,
+} from "@blueprintjs/core";
+import { AppContext } from "../../context";
+import { useAPIResult } from "@macrostrat/ui-components";
+import { base, MAP_MODES } from "../../context";
+
+const projects_url = process.env.API_BASE + "projects";
+
+function unwrapProjects(res) {
+  if (res.data) {
+    const { data } = res;
+    let projects = data.map((project) => {
+      return {
+        project_id: project.project_id,
+        name: project.name,
+        description: project.description,
+      };
+    });
+    return projects;
+  } else {
+    return [];
+  }
+}
+
+function ProjectDropDown(props) {
+  const { projects } = props;
+  const { state, runAction } = useContext(AppContext);
+  const changeProjectId = (project) => {
+    runAction({ type: "change-project", payload: project });
+  };
+
+  const openImportOverlay = () => {
+    runAction({ type: "import-overlay", payload: { open: true } });
+  };
+
+  return (
+    <Menu>
+      {projects.map((project) => {
+        const { project_id: id, name } = project;
+        let iconName: IconName | undefined =
+          id == state.project.project_id ? "tick" : undefined;
+        return (
+          <MenuItem
+            key={id}
+            text={name}
+            onClick={() => changeProjectId(project)}
+            intent="primary"
+            labelElement={<Icon icon={iconName} />}
+          ></MenuItem>
+        );
+      })}
+      <MenuDivider />
+
+      <MenuItem text="More..." onClick={openImportOverlay}></MenuItem>
+    </Menu>
+  );
+}
+
+function NavBarModeBtns(props: {
+  changeMode: (mode: MAP_MODES) => void;
+  mode: MAP_MODES;
+}) {
+  const { changeMode, mode } = props;
+
+  return (
+    <React.Fragment>
+      <Button
+        minimal={true}
+        active={mode == MAP_MODES.voronoi}
+        onClick={() => changeMode(MAP_MODES.voronoi)}
+      >
+        Tesselate
+      </Button>
+      <Button
+        minimal={true}
+        active={mode == MAP_MODES.topology}
+        onClick={() => changeMode(MAP_MODES.topology)}
+      >
+        Edit Topology
+      </Button>
+      <Button
+        minimal={true}
+        active={mode == MAP_MODES.properties}
+        onClick={() => changeMode(MAP_MODES.properties)}
+      >
+        View / Edit Properties
+      </Button>
+    </React.Fragment>
+  );
+}
+
+interface NavBarSaveBtnsProps {
+  onSave: () => void;
+  onCancel: () => void;
+  mode: MAP_MODES;
+  project_id: number | null;
+  polygons?: object[];
+  changeSet?: object[];
+}
+
+function NavBarSaveBtns(props: NavBarSaveBtnsProps) {
+  const {
+    onSave,
+    onCancel,
+    project_id,
+    mode,
+    polygons = [],
+    changeSet = [],
+  } = props;
+
+  const disabled =
+    (mode == MAP_MODES.voronoi && !polygons.length) ||
+    (mode == MAP_MODES.topology && !changeSet.length);
+  return (
+    <div className="nav-btn">
+      <Button
+        minimal={true}
+        intent="success"
+        onClick={onSave}
+        disabled={disabled}
+      >
+        {mode == MAP_MODES.voronoi ? "Save Tesselation" : "Save"}
+      </Button>
+      <Button minimal={true} intent="danger" onClick={onCancel}>
+        Cancel
+      </Button>
+      <DownloadButton project_id={project_id} />
+    </div>
+  );
+}
+
+interface MapNavBarProps {
+  onSave: () => void;
+  onCancel: () => void;
+  changeMode: (mode: MAP_MODES) => void;
+  mode: MAP_MODES;
+  project_id: number | null;
+  polygons: object[];
+  changeSet: object[];
+}
+
+function MapNavBar(props: MapNavBarProps) {
+  const { onSave, onCancel, mode, changeMode, project_id, ...rest } = props;
+  const { state, runAction } = useContext(AppContext);
+
+  const openImportOverlay = () => {
+    runAction({ type: "import-overlay", payload: { open: true } });
+  };
+
+  const projects = useAPIResult(
+    projects_url,
+    {},
+    { unwrapResponse: unwrapProjects }
+  );
+  if (!projects) return <div></div>;
+
+  return (
+    <div className="navbar-layout">
+      <Navbar style={{ position: "absolute", top: 0, left: 0 }}>
+        <div className="nav-contents">
+          <div className="nav-left">
+            <Navbar.Heading>
+              <Button minimal={true} onClick={openImportOverlay}>
+                <h2 style={{ margin: 0 }}>BirdsEye</h2>
+              </Button>
+            </Navbar.Heading>
+            <Navbar.Divider />
+            <Navbar.Heading>
+              <Popover
+                content={<ProjectDropDown projects={projects} />}
+                position="bottom"
+                minimal={true}
+              >
+                <Button minimal={true}>
+                  <h3 style={{ margin: 0 }}>Project: {state.project.name}</h3>
+                </Button>
+              </Popover>
+            </Navbar.Heading>
+          </div>
+          <div className="nav-right">
+            <NavBarModeBtns mode={mode} changeMode={changeMode} />
+            <Navbar.Divider />
+            <NavBarSaveBtns
+              mode={mode}
+              project_id={project_id}
+              onSave={onSave}
+              onCancel={onCancel}
+              {...rest}
+            />
+          </div>
+        </div>
+      </Navbar>
+    </div>
+  );
+}
+
+export { MapNavBar };

--- a/packages/column-footprint-editor/src/components/blueprint/select.tsx
+++ b/packages/column-footprint-editor/src/components/blueprint/select.tsx
@@ -1,0 +1,92 @@
+import { Suggest } from "@blueprintjs/select";
+import { Icon, MenuItem } from "@blueprintjs/core";
+import React, { useState, useEffect } from "react";
+
+export function MySuggest(props) {
+  const {
+    items,
+    onChange,
+    onFilter = () => {},
+    initialQuery,
+    createNew = true,
+    ...rest
+  } = props;
+  const [selectedItem, setSelectedItem] = useState({});
+  const [query, setQuery] = useState("");
+
+  let itemz = [...items];
+
+  useEffect(() => {
+    if (initialQuery && initialQuery != "") {
+      setQuery(initialQuery);
+      itemz = [...itemz, { text: initialQuery }];
+      setSelectedItem(initialQuery);
+    }
+  }, [initialQuery]);
+
+  const itemRenderer = (item, itemProps) => {
+    const isSelected = item == selectedItem;
+    const { id, text } = item;
+    return (
+      <MenuItem
+        key={id}
+        labelElement={isSelected ? <Icon icon="tick" /> : null}
+        intent={isSelected ? "primary" : null}
+        text={text}
+        onClick={itemProps.handleClick}
+        active={isSelected ? "active" : itemProps.modifiers.active}
+      />
+    );
+  };
+
+  const onQueryChange = (query) => {
+    onFilter(query);
+  };
+
+  const itemPredicate = (query, item) => {
+    const { id, text } = item;
+
+    return text.toLowerCase().indexOf(query.toLowerCase()) >= 0;
+  };
+
+  const onItemSelect = (item) => {
+    onChange(item);
+    setSelectedItem(item.text);
+  };
+
+  const createNewItemRenderer = (query, itemProps) => {
+    return (
+      <MenuItem
+        icon="add"
+        text={`Create ${query}`}
+        onClick={() => onChange(query)}
+        intent="success"
+      />
+    );
+  };
+
+  const createNewItemFromQuery = (query) => {
+    return query;
+  };
+
+  return (
+    <div>
+      <Suggest
+        inputValueRenderer={(item) => item.text}
+        items={itemz}
+        popoverProps={{
+          minimal: true,
+          popoverClassName: "my-suggest",
+        }}
+        query={query}
+        onItemSelect={onItemSelect}
+        onQueryChange={onQueryChange}
+        itemRenderer={itemRenderer}
+        itemPredicate={itemPredicate}
+        selectedItem
+        createNewItemRenderer={createNew ? createNewItemRenderer : null}
+        createNewItemFromQuery={createNew ? createNewItemFromQuery : null}
+      />
+    </div>
+  );
+}

--- a/packages/column-footprint-editor/src/components/blueprint/toaster.tsx
+++ b/packages/column-footprint-editor/src/components/blueprint/toaster.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Toaster, Icon, ProgressBar } from "@blueprintjs/core";
+
+const AppToaster = Toaster.create({
+  position: "top",
+  maxToasts: 1,
+});
+
+const SavingToast = ({ message = "Saving..." }) => {
+  return (
+    <div>
+      <h4 style={{ marginLeft: "10px", margin: "0px" }}>{message}</h4>
+      <ProgressBar />
+    </div>
+  );
+};
+
+const SuccessfullySaved = () => {
+  return (
+    <div style={{ display: "flex" }}>
+      <Icon style={{ marginRight: "10px" }} icon="tick" />
+      <h4 style={{ margin: "0px" }}>Saved Successfully!</h4>
+    </div>
+  );
+};
+
+const BadSaving = () => {
+  return (
+    <div style={{ display: "flex" }}>
+      <Icon style={{ marginRight: "10px" }} icon="error" />
+      Error While Saving
+    </div>
+  );
+};
+
+export { AppToaster, SavingToast, SuccessfullySaved, BadSaving };

--- a/packages/column-footprint-editor/src/components/editor/column-groups/column-suggest.tsx
+++ b/packages/column-footprint-editor/src/components/editor/column-groups/column-suggest.tsx
@@ -1,0 +1,93 @@
+import { Suggest } from "@blueprintjs/select";
+import { Icon, MenuItem } from "@blueprintjs/core";
+import React, { useState, useEffect } from "react";
+
+export function ColumnSuggest(props) {
+  const {
+    items,
+    onChange,
+    onFilter = () => {},
+    initialItem,
+    createNew = false,
+    ...rest
+  } = props;
+  const [selectedItem, setSelectedItem] = useState({});
+  const [query, setQuery] = useState("");
+
+  let itemz = [...items];
+
+  let initialQuery = initialItem.col_group_name;
+  useEffect(() => {
+    if (initialQuery && initialQuery != "") {
+      setQuery(initialQuery);
+      itemz = [...itemz];
+      setSelectedItem(initialQuery);
+    }
+  }, [initialQuery]);
+
+  const itemRenderer = (item, itemProps) => {
+    const isSelected = item == selectedItem;
+    const { id, col_group, col_group_name } = item;
+    return (
+      <MenuItem
+        key={id}
+        labelElement={col_group}
+        intent={isSelected ? "primary" : null}
+        text={col_group_name}
+        onClick={itemProps.handleClick}
+        active={isSelected ? "active" : itemProps.modifiers.active}
+      />
+    );
+  };
+
+  const onQueryChange = (query) => {
+    onFilter(query);
+  };
+
+  const itemPredicate = (query, item) => {
+    const { id, col_group_name } = item;
+
+    return col_group_name.toLowerCase().indexOf(query.toLowerCase()) >= 0;
+  };
+
+  const onItemSelect = (item) => {
+    onChange(item);
+    setSelectedItem(item.col_group_name);
+  };
+
+  const createNewItemRenderer = (query, itemProps) => {
+    return (
+      <MenuItem
+        icon="add"
+        text={`Create ${query}`}
+        onClick={() => onChange(query)}
+        intent="success"
+      />
+    );
+  };
+
+  const createNewItemFromQuery = (query) => {
+    return query;
+  };
+
+  return (
+    <div>
+      <Suggest
+        inputValueRenderer={(item) => item.col_group_name}
+        items={itemz}
+        popoverProps={{
+          minimal: true,
+        }}
+        inputProps={{ fill: true, style: { minWidth: "350px" } }}
+        query={query}
+        onItemSelect={onItemSelect}
+        onQueryChange={onQueryChange}
+        itemRenderer={itemRenderer}
+        itemPredicate={itemPredicate}
+        selectedItem
+        createNewItemRenderer={createNew ? createNewItemRenderer : null}
+        createNewItemFromQuery={createNew ? createNewItemFromQuery : null}
+      />
+    </div>
+  );
+}

--- a/packages/column-footprint-editor/src/components/editor/column-groups/editor.tsx
+++ b/packages/column-footprint-editor/src/components/editor/column-groups/editor.tsx
@@ -1,0 +1,113 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import {
+  Overlay,
+  Button,
+  Card,
+  Navbar,
+  FormGroup,
+  Collapse,
+} from "@blueprintjs/core";
+import { useAPIResult, useModelEditor } from "@macrostrat/ui-components";
+import { ColumnSuggest } from "./column-suggest";
+import { NewColGroups } from "./new-column";
+import { AppContext } from "../../../context";
+import { base } from "../../../context/env";
+import { EditColGroup } from ".";
+
+function unwrapColumnGroups(res) {
+  const { data } = res;
+  return data;
+}
+
+function ColumnGroup() {
+  const { model, isEditing, actions } = useModelEditor();
+  const { state } = useContext(AppContext);
+  const [open, setOpen] = useState(false);
+  const [openEdit, setOpenEdit] = useState(false);
+
+  const { project } = state;
+  const { project_id } = project;
+
+  const data = useAPIResult(
+    base + `${project_id}/col-groups`,
+    {},
+    { unwrapResponse: unwrapColumnGroups }
+  );
+
+  if (!data) return <div />;
+
+  const { col_group, col_group_name, col_group_id } = model;
+
+  const onChangeGroup = (e) => {
+    actions.updateState({
+      model: {
+        col_group: { $set: e.col_group },
+        col_group_id: { $set: e.id },
+        col_group_name: { $set: e.col_group_name },
+      },
+    });
+  };
+
+  const onCreateColGroup = (col_group_id, col_group, col_group_name) => {
+    setOpen(false);
+    actions.updateState({
+      model: {
+        col_group: { $set: col_group },
+        col_group_id: { $set: col_group_id },
+        col_group_name: { $set: col_group_name },
+      },
+    });
+  };
+
+  if (isEditing) {
+    return (
+      <div>
+        <FormGroup label="Column group">
+          <ColumnSuggest
+            items={data}
+            onChange={onChangeGroup}
+            initialItem={model}
+          />
+        </FormGroup>
+        <div style={{ margin: "10px", marginLeft: "0px" }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <Button
+              onClick={() => {
+                setOpen(!open);
+              }}
+              intent="success"
+            >
+              New Column Group
+            </Button>
+            <Button
+              onClick={() => {
+                setOpenEdit(!openEdit);
+              }}
+              disabled={model.col_group_id == undefined ? true : false}
+              intent="success"
+            >
+              Edit Column Group
+            </Button>
+          </div>
+        </div>
+        <Collapse isOpen={open}>
+          <div className="new-column-collapse">
+            <NewColGroups onCreate={onCreateColGroup} />
+          </div>
+        </Collapse>
+        <Collapse isOpen={openEdit}>
+          <div className="new-column-collapse">
+            <EditColGroup onCreate={onCreateColGroup} state={model} />
+          </div>
+        </Collapse>
+      </div>
+    );
+  }
+  return (
+    <div className="col-group-text">
+      {col_group_name} <i>({col_group})</i>
+    </div>
+  );
+}
+
+export { ColumnGroup };

--- a/packages/column-footprint-editor/src/components/editor/column-groups/index.ts
+++ b/packages/column-footprint-editor/src/components/editor/column-groups/index.ts
@@ -1,0 +1,3 @@
+export * from "./editor";
+export * from "./column-suggest";
+export * from "./new-column";

--- a/packages/column-footprint-editor/src/components/editor/column-groups/new-column.tsx
+++ b/packages/column-footprint-editor/src/components/editor/column-groups/new-column.tsx
@@ -1,0 +1,127 @@
+import React, { useContext, useEffect, useState } from "react";
+import {
+  ModelEditor,
+  useModelEditor,
+  ModelEditButton,
+  EditableMultilineText,
+} from "@macrostrat/ui-components";
+import { Popover2 } from "@blueprintjs/popover2";
+import { SaveButton } from "../../blueprint";
+import axios from "axios";
+import { ChromePicker } from "react-color";
+
+import { AppContext } from "../../../context";
+import { base } from "../../../context/env";
+import { FormGroup, InputGroup } from "@blueprintjs/core";
+
+function ColorPicker() {
+  const { model, isEditing, actions } = useModelEditor();
+  const { color } = model;
+
+  const onChangeColor = (color) => {
+    const { hex } = color;
+    actions.updateState({ model: { color: { $set: hex } } });
+  };
+
+  if (!isEditing) return <div />;
+  return (
+    <div>
+      <Popover2
+        content={
+          <ChromePicker onChangeComplete={onChangeColor} color={color} />
+        }
+      >
+        <div className="color-block" style={{ backgroundColor: color }}></div>
+      </Popover2>
+    </div>
+  );
+}
+
+function EditComponents() {
+  const { actions, model } = useModelEditor();
+
+  const update = (field, value) => {
+    actions.updateState({
+      model: { [field]: { $set: value } },
+    });
+  };
+  return (
+    <div>
+      <FormGroup label="Column group">
+        <InputGroup
+          onChange={(e) => update("col_group", e.target.value)}
+          value={model["col_group"]}
+        />
+      </FormGroup>
+      <FormGroup label="Column group name">
+        <InputGroup
+          onChange={(e) => update("col_group_name", e.target.value)}
+          value={model["col_group_name"]}
+        />
+      </FormGroup>
+
+      <ColorPicker />
+      <SaveButton onClick={() => actions.persistChanges()} />
+    </div>
+  );
+}
+
+function NewColGroups(props) {
+  const { onCreate } = props;
+  let state = {
+    col_group: "",
+    col_group_name: "",
+    color: "",
+  };
+
+  const { state: appState } = useContext(AppContext);
+  const project_id = appState.project.project_id;
+  const persistChanges = async (updatedModel, changeset) => {
+    let route = base + `${project_id}/col-groups`;
+    let res = await axios.post(route, { updatedModel });
+    const {
+      data: { col_group_id },
+    } = res;
+    const { col_group, col_group_name } = updatedModel;
+    onCreate(col_group_id, col_group, col_group_name);
+  };
+
+  return <BaseColGroupEditor state={state} persistChanges={persistChanges} />;
+}
+
+function EditColGroup(props) {
+  const { onCreate, state } = props;
+
+  const { state: appState } = useContext(AppContext);
+  const project_id = appState.project.project_id;
+
+  const persistChanges = async (updatedModel, changeset) => {
+    console.log(updatedModel);
+    let route = base + `${project_id}/col-groups`;
+    let res = await axios.put(route, { updatedModel });
+    const {
+      data: { id },
+    } = res;
+    const { col_group, col_group_name } = updatedModel;
+    onCreate(id, col_group, col_group_name);
+  };
+
+  return <BaseColGroupEditor state={state} persistChanges={persistChanges} />;
+}
+
+function BaseColGroupEditor(props) {
+  const { state, persistChanges } = props;
+
+  return (
+    <ModelEditor
+      model={state}
+      canEdit={true}
+      isEditing={true}
+      persistChanges={persistChanges}
+    >
+      <EditComponents />
+    </ModelEditor>
+  );
+}
+
+export { NewColGroups, EditColGroup };

--- a/packages/column-footprint-editor/src/components/editor/editor.tsx
+++ b/packages/column-footprint-editor/src/components/editor/editor.tsx
@@ -1,0 +1,204 @@
+import React, { useContext } from "react";
+import { Navbar, InputGroup, FormGroup, TextArea } from "@blueprintjs/core";
+import { OverlayBox, SaveButton } from "../blueprint";
+import {
+  ModelEditor,
+  useModelEditor,
+  ModelEditButton,
+  EditableMultilineText,
+} from "@macrostrat/ui-components";
+import axios from "axios";
+import { AppContext } from "../../context";
+
+import {
+  AppToaster,
+  SavingToast,
+  SuccessfullySaved,
+  BadSaving,
+} from "../blueprint";
+
+import "./main.css";
+
+import { ColumnGroup } from "./column-groups";
+import { base } from "../../context/env";
+
+const canSave = (model): boolean => {
+  const { col_name = null, description = null, col_group_name = null } = model;
+  if (col_name && description && col_group_name) return true;
+  return false;
+};
+
+function ColumnNavBar({ onMouseDown }) {
+  const { model, isEditing, hasChanges, actions, ...rest } = useModelEditor();
+
+  const buttonText = isEditing ? "Cancel" : "Edit";
+  const buttonIntent = isEditing ? "danger" : "success";
+
+  return (
+    <div className="column-nav-bar" onMouseDown={onMouseDown}>
+      <Navbar>
+        <div className="column-nav-container">
+          <div style={{ display: "flex", alignItems: "center" }}>
+            Column ID: {model.col_id}
+            <Navbar.Divider />
+            Project ID: {model.project_id}
+          </div>
+          <div>
+            <SaveButton
+              minimal={true}
+              disabled={!isEditing || !canSave(model)}
+              onClick={async () => {
+                actions.persistChanges();
+                actions.toggleEditing();
+              }}
+            ></SaveButton>
+            <ModelEditButton intent={buttonIntent} minimal={true}>
+              {buttonText}
+            </ModelEditButton>
+          </div>
+        </div>
+      </Navbar>
+    </div>
+  );
+}
+
+function ColumnName() {
+  const { model, isEditing, actions } = useModelEditor();
+  const { col_name } = model;
+
+  const updateName = (name) => {
+    actions.updateState({
+      model: { col_name: { $set: name.target.value } },
+    });
+  };
+
+  if (isEditing) {
+    return (
+      <FormGroup label="Column name">
+        <InputGroup onChange={updateName} value={col_name} />
+      </FormGroup>
+    );
+  }
+  return <div className="column-name-text">{col_name}</div>;
+}
+
+function ColumnDescription() {
+  const { model, isEditing, actions } = useModelEditor();
+  let { description = "No description" } = model;
+
+  const updateDescription = (e) => {
+    actions.updateState({
+      model: { description: { $set: e.target.value } },
+    });
+  };
+
+  if (isEditing) {
+    return (
+      <FormGroup label="Column description">
+        <TextArea onChange={updateDescription} value={description} />
+      </FormGroup>
+    );
+  }
+  return <div className="description-text">{description}</div>;
+}
+
+function FeatureOverlay({ feature, open }) {
+  return (
+    <div className="editor-overlay">
+      <ColumnName />
+      <ColumnGroup />
+      <ColumnDescription />
+    </div>
+  );
+}
+
+function PropertyDialog(props) {
+  const {
+    state: appState,
+    runAction,
+    updateLinesAndColumns,
+  } = useContext(AppContext);
+  const { features, open, closeOpen, setFeatures } = props;
+  const feature = features[0];
+  if (!feature) return null;
+
+  const {
+    col_group,
+    col_group_name,
+    col_group_id,
+    col_id,
+    col_name,
+    description,
+    color,
+    id: identity_id,
+  } = feature["properties"];
+
+  let state = {
+    id: feature.id,
+    col_group,
+    col_group_name,
+    col_group_id,
+    project_id: appState.project.project_id,
+    location: feature.geometry || feature.properties.location,
+    col_id,
+    col_name,
+    color,
+    description,
+    identity_id,
+  };
+  const put_url = base + `projects`;
+
+  const persistChanges = async (updatedModel, changeSet) => {
+    console.log(updatedModel);
+    if (Object.keys(updatedModel).length > 0) {
+      runAction({ type: "is-saving", payload: { isSaving: true } });
+      AppToaster.show({
+        message: <SavingToast />,
+        intent: "primary",
+      });
+      try {
+        await axios.put(put_url, {
+          updatedModel,
+          project_id: updatedModel.project_id,
+        });
+        AppToaster.show({
+          message: <SuccessfullySaved />,
+          intent: "success",
+          timeout: 3000,
+        });
+        updateLinesAndColumns(updatedModel.project_id);
+        runAction({ type: "is-saving", payload: { isSaving: false } });
+      } catch {
+        AppToaster.show({
+          message: <BadSaving />,
+          intent: "danger",
+          timeout: 5000,
+        });
+        updateLinesAndColumns(updatedModel.project_id);
+        runAction({ type: "is-saving", payload: { isSaving: false } });
+      }
+    }
+    const newFeature = { properties: updatedModel, id: updatedModel.id };
+    newFeature.properties.id = newFeature.properties.identity_id;
+    setFeatures([newFeature]);
+  };
+
+  return (
+    <ModelEditor
+      model={state}
+      canEdit={true}
+      isEditing={false}
+      persistChanges={persistChanges}
+    >
+      <OverlayBox
+        open={open}
+        closeOpen={closeOpen}
+        HeaderComponent={ColumnNavBar}
+      >
+        <FeatureOverlay feature={state} open={open} />
+      </OverlayBox>
+    </ModelEditor>
+  );
+}
+
+export { PropertyDialog };

--- a/packages/column-footprint-editor/src/components/editor/index.ts
+++ b/packages/column-footprint-editor/src/components/editor/index.ts
@@ -1,0 +1,1 @@
+export * from "./editor";

--- a/packages/column-footprint-editor/src/components/editor/main.css
+++ b/packages/column-footprint-editor/src/components/editor/main.css
@@ -1,0 +1,100 @@
+@import "~/node_modules/@blueprintjs/core/lib/css/blueprint.css";
+@import "~/node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css";
+@import "~/node_modules/@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+
+.bp4-menu {
+  max-height: 200px;
+  overflow: scroll;
+}
+
+.column-name-text {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.col-group-text {
+  font-size: 16px;
+  color: #5f6b7c;
+}
+.description-text {
+  margin-top: 5px;
+}
+.editor-overlay {
+  margin-top: 10px;
+  min-height: 100px;
+}
+
+.clicked-entity {
+  background-color: #ced9e0;
+}
+.color-block {
+  height: 25px;
+  width: 25px;
+  border-radius: 5px;
+  box-shadow: 0px 2px 3px 0px;
+}
+.edit-with-label {
+  display: flex;
+  align-items: baseline;
+  margin: 10px;
+  margin-left: 0px;
+}
+
+.new-column-collapse {
+  border-style: solid;
+  border-color: #ced9e0;
+  border-radius: 5px;
+  border-width: 1px;
+  margin-bottom: 5px;
+  padding: 10px;
+}
+
+.h4-0 {
+  margin: 0px;
+  margin-right: 5px;
+}
+
+.map-legend-overlay {
+  top: 85px;
+  right: 30px;
+  max-width: 500px;
+  min-width: 300px;
+}
+
+.map-legend-row {
+  display: flex;
+  align-items: baseline;
+  margin-bottom: "5px";
+  overflow-y: auto;
+  justify-content: space-between;
+}
+
+.col-group-legend {
+  color: rgb(170, 170, 170);
+}
+
+.import-feedback-dialog {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 250px;
+}
+
+.column-nav-bar {
+  margin-top: -20px;
+  margin-left: -20px;
+  margin-right: -20px;
+  cursor: grab;
+}
+.column-nav-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 10px;
+}
+
+.about-container {
+  height: 80vh;
+  overflow: auto;
+}

--- a/packages/column-footprint-editor/src/components/editor/no-identity.tsx
+++ b/packages/column-footprint-editor/src/components/editor/no-identity.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Navbar } from "@blueprintjs/core";
+
+function Header(props) {}
+
+function NoIdentity(props) {
+  const { feature } = props;
+}

--- a/packages/column-footprint-editor/src/components/editor/two-identities.tsx
+++ b/packages/column-footprint-editor/src/components/editor/two-identities.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Navbar, Card, Icon } from "@blueprintjs/core";
+import { SaveButton } from "../blueprint";
+
+function Header(props) {
+  const { onSave, disabled } = props;
+
+  return (
+    <Navbar>
+      <Navbar.Group>
+        <h4 style={{ color: "#DB3737" }}>Warning, more than one identity</h4>
+        <Navbar.Divider />
+        <h4>Choose one</h4>
+        <Navbar.Divider />
+        <SaveButton minimal={true} onClick={onSave} disabled={disabled} />
+      </Navbar.Group>
+    </Navbar>
+  );
+}
+
+function Body(props) {
+  const { features, onClickID, clickedID } = props;
+
+  return (
+    <div style={{ display: "flex", marginTop: "20px" }}>
+      {features.map((feature, indx) => {
+        const {
+          col_group: group,
+          project_id,
+          col_id: column_id,
+          col_name: column_name,
+          id: identity_id,
+        } = feature["properties"];
+
+        let className = clickedID == indx ? "clicked-entity" : "not-clicked";
+        let iconName = clickedID == indx ? "selection" : "circle";
+
+        return (
+          <Card
+            className={className}
+            key={indx}
+            elevation={1}
+            interactive={true}
+            onClick={() => onClickID(indx)}
+          >
+            <h4>
+              Column: {column_name} ({column_id}))
+            </h4>
+            <h4>Column Group: {group}</h4>
+            <h4>Project ID: {project_id}</h4>
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <Icon icon={iconName} />
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function TwoIdentities(props) {
+  const { features } = props;
+
+  const [clickedID, setClickedID] = React.useState(null);
+
+  const disabled = clickedID == null;
+
+  const onClickID = (indx) => {
+    setClickedID(indx);
+  };
+
+  const onSave = () => {
+
+    // we will want to remove the other ids from the polygon identifier table. 
+    // the identity_id is the col_id in map_digitizer.polygon table
+    console.log(features[clickedID]);
+  };
+
+  return (
+    <div>
+      <Header onSave={onSave} disabled={disabled} />
+      <Body features={features} onClickID={onClickID} clickedID={clickedID} />
+    </div>
+  );
+}
+
+export { TwoIdentities };

--- a/packages/column-footprint-editor/src/components/importer/about-panel.tsx
+++ b/packages/column-footprint-editor/src/components/importer/about-panel.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+
+function AboutPanel() {
+  return (
+    <div className="about-container">
+      <h2>BirdsEye</h2>
+      <p>
+        BirdsEye is an application that is aimed at editing GeoJSON polygons
+        <b>
+          {" "}
+          <i>while</i>
+        </b>{" "}
+        keeping topology. Users can use the <b>Edit Topology</b> mode to create
+        new column footprint geometries. The <b>Tessellate</b> mode can be used
+        to create polygons inside a bounding geometry or quickly create polygons
+        from points. The <b>View/ Edit Properties</b> mode to add column-group
+        and column-name information. This application is being developed at{" "}
+        <a href="https://macrostrat.org/" target="_blank">
+          {" "}
+          UW-Macrostrat
+        </a>
+        .
+      </p>
+      <p>
+        This application is driven by frontend user interactions, a Python
+        RestAPI, and a PostgreSQL database, which manages topology using{" "}
+        <a
+          href="https://github.com/davenquinn/postgis-geologic-map"
+          target="_blank"
+        >
+          Postgis-Geologic-Map
+        </a>
+        .
+      </p>
+      <h2>How To Use</h2>
+      <p>
+        A user can create a new project by following the directions in the{" "}
+        <i>Projects</i> tab. Once an empty project is created the user can begin
+        adding geometries to the map by either using the <i>line-tool</i> or the{" "}
+        <i>polygon-tool</i>. Both of which are availble on the <b>LEFT</b> side
+        of the map when in <b>Edit Topology</b> mode.
+      </p>
+      <p>
+        When using the <i>line-tool</i> make sure that each vertix of the line
+        is connected to another vertix before you finish drawing (press{" "}
+        <i>enter / return</i>). If there are any unconnected vertices, i.e
+        unclosed lines, then the polygon will not be created on save.
+      </p>
+      <p>
+        All vertices that meet or are grouped together, can be{" "}
+        <i>
+          <b>dragged</b>
+        </i>{" "}
+        together. To ungroup vertices, hold <b>shift</b> while you click on a
+        vertix. This will bypass the multiple dragging mode.
+      </p>
+      <p>
+        There is an option to create a new n-sided polygon (n {">="} 3 ) as a
+        base for your geometric footprint. When in <i>Edit Topology</i> the
+        second option from the top will place you in the <b>Polygon Drawing</b>{" "}
+        mode. Click anywhere once and move your mouse. By default, a hexgon
+        appears and dynamically changes sizes as you move your cursor from the
+        original clicked point on the map.
+      </p>
+      <p>
+        To increase the number of sides the polygon has, press the{" "}
+        <i>
+          <b>a</b>
+        </i>{" "}
+        key while the mode is active. Similarly, press the{" "}
+        <i>
+          <b>s</b>
+        </i>
+        key to subtract from the number of sides the polgyon has. To finish and
+        create the polygon, press{" "}
+        <i>
+          <b>enter</b>
+        </i>{" "}
+        or to exit without creating press the{" "}
+        <i>
+          <b>esc</b>
+        </i>{" "}
+        key.
+      </p>
+      <p>
+        If you find an bug report it{" "}
+        <a href=" https://github.com/Idzikowski-Casey/column-topology/issues">
+          here
+        </a>
+        !
+      </p>
+      <h3>Development Team</h3>
+      <ul>
+        <li className="dev-team">
+          <a
+            href="https://idzikowski-casey.github.io/personal-site/"
+            target="_blank"
+          >
+            Casey Idzikowski
+          </a>
+          , Research Specialist and lead developer.
+        </li>
+        <li className="dev-team">
+          <a href="https://davenquinn.com/" target="_blank">
+            Daven Quinn
+          </a>
+          , Research scientist and Postgis-Geologic-Map developer
+        </li>
+      </ul>
+      <div>
+        <a href="https://github.com/Idzikowski-Casey/column-topology">Github</a>
+        {" | "}
+        <a href="https://github.com/davenquinn/postgis-geologic-map">
+          Postgis-Geologic-Map
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export { AboutPanel };

--- a/packages/column-footprint-editor/src/components/importer/import-overlay.tsx
+++ b/packages/column-footprint-editor/src/components/importer/import-overlay.tsx
@@ -1,0 +1,297 @@
+import React, { useState, useContext } from "react";
+import {
+  Dialog,
+  Card,
+  Button,
+  Spinner,
+  Icon,
+  Divider,
+} from "@blueprintjs/core";
+import { useAPIResult } from "@macrostrat/ui-components";
+import axios from "axios";
+
+import { AppContext } from "../../context";
+import { NewProject } from "./new-project";
+import { base } from "../../context/env";
+import { AboutPanel } from "./about-panel";
+import { PanelStack } from "./panel-stack";
+
+const import_url = base + "import";
+
+// https://macrostrat.org/api/v2/defs/projects?all lists projects in macrostrat
+
+function Project(props) {
+  const { project, onClickImport, text } = props;
+  return (
+    <div style={{ margin: "5px" }} key={project.project_id}>
+      <div>
+        <h5>Project ID: {project.project_id}</h5>
+        <h5>Project Name: {project.name}</h5>
+        <p>Project Description: {project.description}</p>
+        <Button onClick={() => onClickImport(project)} intent="primary">
+          {text}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const getMacrostratProjects = () => {
+  const url = "https://macrostrat.org/api/v2/defs/projects?all";
+
+  const unwrapData = (res) => {
+    if (res) {
+      const data = res.success.data.map((project) => {
+        const { project_id, project: name, descrip: description } = project;
+        return { project_id, name, description };
+      });
+      return data;
+    } else {
+      return [];
+    }
+  };
+
+  const data = useAPIResult(url, {}, { unwrapResponse: unwrapData });
+  return data;
+};
+
+function ImportableProjectPanel(props) {
+  const { runAction } = useContext(AppContext);
+  const [alert, setAlert] = useState(false);
+  const [importing, setImporting] = useState(false);
+
+  const { project } = props;
+
+  const onClickImport = async (project) => {
+    let data = {
+      project_id: project.project_id,
+      name: project.name,
+      description: project.description,
+    };
+
+    setAlert(true);
+    setImporting(true);
+    let res = await axios.post(import_url, data);
+    // needs to have some more stuff here for feedback
+    if (res.status == 200) {
+      setImporting(false);
+      setTimeout(() => {
+        setAlert(false);
+        runAction({ type: "change-project", payload: data });
+      }, 2000);
+    }
+  };
+
+  let mainText = importing ? "Importing Project" : "Finished!";
+  let visualComponent = importing ? (
+    <Spinner />
+  ) : (
+    <Icon icon="tick" intent="success" size={55} />
+  );
+  let lowerText = importing
+    ? "This may take a minute.."
+    : "Wait to be redirected";
+
+  return (
+    <div>
+      <Project project={project} onClickImport={onClickImport} text="import" />
+      <Dialog isOpen={alert} className="import-feedback-dialog">
+        <h4>{mainText}</h4>
+        {visualComponent}
+        <h5>{lowerText}</h5>{" "}
+      </Dialog>
+    </div>
+  );
+}
+
+function ImportableProjects(props) {
+  const projectData = getMacrostratProjects();
+
+  if (!projectData) return <div></div>;
+
+  const openNewPanel = (project) => {
+    props.openPanel({
+      props: {
+        project,
+      },
+      renderPanel: ImportableProjectPanel,
+      title: "Import " + project.name,
+    });
+  };
+
+  return (
+    <div>
+      <h3>Projects Available for Import</h3>
+      {projectData.map((project, i) => {
+        return (
+          <Button
+            key={i}
+            className="project-btns"
+            onClick={() => openNewPanel(project)}
+          >
+            {project.name}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+function EditableProjects(props) {
+  const { state, runAction } = useContext(AppContext);
+
+  let projectsUrl = base + "projects";
+  const unwrapProjects = (res) => {
+    const data = res.data.map((project) => {
+      const { project_id, name, description } = project;
+      return { project_id, name, description };
+    });
+    return data;
+  };
+  const data = useAPIResult(
+    projectsUrl,
+    {},
+    { unwrapResponse: unwrapProjects }
+  );
+  if (!data) return <div></div>;
+
+  const openNewPanel = (project) => {
+    props.openPanel({
+      props: {
+        project,
+        onClickImport: () => changeProjectId(project),
+        text: "Edit",
+      },
+      renderPanel: Project,
+      title: "Edit " + project.name,
+    });
+  };
+
+  const changeProjectId = (project) => {
+    runAction({ type: "change-project", payload: project });
+  };
+
+  return (
+    <div>
+      <h3>Projects Available for Editing in Databse</h3>
+      {data.map((project, i) => {
+        return (
+          <Button
+            key={i}
+            className="project-btns"
+            onClick={() => openNewPanel(project)}
+          >
+            {project.name}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+enum MenuPanel {
+  PROJECT,
+  ABOUT,
+}
+
+function ImportPanels() {
+  const [panel, setPanel] = useState<MenuPanel>(MenuPanel.PROJECT);
+
+  const setProjects = () => {
+    setPanel(MenuPanel.PROJECT);
+  };
+  const setAbout = () => {
+    setPanel(MenuPanel.ABOUT);
+  };
+  return (
+    <div>
+      <div className="main-dialog-header">
+        <Button
+          rightIcon="send-to-graph"
+          onClick={setProjects}
+          minimal
+          active={panel == MenuPanel.PROJECT}
+        >
+          Projects
+        </Button>
+        <Button
+          rightIcon="info-sign"
+          onClick={setAbout}
+          minimal
+          active={panel == MenuPanel.ABOUT}
+        >
+          About
+        </Button>
+      </div>
+      <Divider />
+      <PanelRender panel={panel} />
+    </div>
+  );
+}
+
+function PanelRender({ panel }) {
+  const initialPanel = {
+    props: {
+      panelNumber: 1,
+    },
+    renderPanel: ProjectPanel,
+    title: "Project Actions",
+  };
+  return (
+    <div>
+      {panel == MenuPanel.ABOUT ? (
+        <AboutPanel />
+      ) : (
+        <PanelStack
+          initialPanel={initialPanel}
+          renderActivePanelOnly={false}
+          className="panel-stack"
+        />
+      )}
+    </div>
+  );
+}
+
+function ProjectPanel(props) {
+  return (
+    <div>
+      <EditableProjects {...props} />
+      <ImportableProjects {...props} />
+      <NewProject {...props} />
+    </div>
+  );
+}
+
+function ImportDialog(props) {
+  const { state, runAction } = useContext(AppContext);
+
+  const isCloseButtonShown = state.project.project_id != null;
+
+  const onClose = () => {
+    runAction({ type: "import-overlay", payload: { open: false } });
+  };
+
+  return (
+    <Dialog
+      isOpen={state.importOverlayOpen}
+      canOutsideClickClose={isCloseButtonShown}
+      canEscapeKeyClose={isCloseButtonShown}
+      onClose={onClose}
+    >
+      <Card>
+        <div className="btn-holder">
+          <Button
+            rightIcon="cross"
+            minimal={true}
+            intent="danger"
+            onClick={onClose}
+            disabled={!isCloseButtonShown}
+          />
+        </div>
+        <ImportPanels />
+      </Card>
+    </Dialog>
+  );
+}
+
+export { ImportDialog };

--- a/packages/column-footprint-editor/src/components/importer/index.ts
+++ b/packages/column-footprint-editor/src/components/importer/index.ts
@@ -1,0 +1,1 @@
+export * from "./import-overlay";

--- a/packages/column-footprint-editor/src/components/importer/new-project.tsx
+++ b/packages/column-footprint-editor/src/components/importer/new-project.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useContext } from "react";
+import {
+  Button,
+  InputGroup,
+  FormGroup,
+  EditableText,
+  Spinner,
+  Icon,
+  Dialog,
+  Collapse,
+} from "@blueprintjs/core";
+import axios from "axios";
+import { AppContext } from "../../context";
+import { base } from "../../context/env";
+
+function NewProject(props) {
+  const openNewPanel = () => {
+    props.openPanel({
+      renderPanel: NewProjectFormPanel,
+      title: "Create New Project",
+    });
+  };
+  return (
+    <div>
+      <h3>Create a New Project</h3>
+      <Button onClick={openNewPanel} intent="primary">
+        Create
+      </Button>
+    </div>
+  );
+}
+
+function NewProjectFormPanel(props) {
+  const { state, runAction } = useContext(AppContext);
+  const [alert, setAlert] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [project, setProject] = useState({
+    name: "",
+    description: "",
+  });
+
+  const setName = (e) => {
+    const state = { ...project };
+    setProject({ name: e.target.value, description: state.description });
+  };
+  const setDescription = (e) => {
+    const state = { ...project };
+
+    setProject({ name: state.name, description: e });
+  };
+
+  const onSubmit = async () => {
+    const data = { data: project };
+    let url = base + "projects";
+    setAlert(true);
+    setImporting(true);
+    const res = await axios.post(url, data);
+    if (res.status == 200) {
+      setImporting(false);
+      setTimeout(() => {
+        setAlert(false);
+        runAction({
+          type: "change-project",
+          payload: {
+            project_id: res.data.project_id,
+            name: project.name,
+            description: project.description,
+          },
+        });
+      }, 2000);
+    }
+  };
+  let mainText = importing ? "Creating New Project" : "Finished!";
+  let visualComponent = importing ? (
+    <Spinner />
+  ) : (
+    <Icon icon="tick" intent="success" size={55} />
+  );
+  let lowerText = importing
+    ? "This may take a minute.."
+    : "Wait to be redirected";
+  return (
+    <div style={{ marginTop: "15px", padding: "5px" }}>
+      <FormGroup label="Project Name">
+        <InputGroup value={project.name} onChange={setName} />
+      </FormGroup>
+      <FormGroup label="Project Description">
+        <EditableText
+          multiline={true}
+          placeholder="Add a project description"
+          value={project.description}
+          onChange={setDescription}
+        />
+      </FormGroup>
+      <div>
+        <Button onClick={() => props.closePanel()} intent="danger">
+          Cancel
+        </Button>
+        <Button onClick={onSubmit} intent="success">
+          Create Project
+        </Button>
+      </div>
+      <Dialog isOpen={alert} className="import-feedback-dialog">
+        <h4>{mainText}</h4>
+        {visualComponent}
+        <h5>{lowerText}</h5>{" "}
+      </Dialog>
+    </div>
+  );
+}
+
+export { NewProject };

--- a/packages/column-footprint-editor/src/components/importer/panel-stack.tsx
+++ b/packages/column-footprint-editor/src/components/importer/panel-stack.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { Card, PanelStack2 } from "@blueprintjs/core";
+
+function PanelStack(props) {
+  const [currentStack, setCurrentStack] = useState<Array<any>>([
+    props.initialPanel,
+  ]);
+
+  const addToPanelStack = React.useCallback(
+    (newPanel) => setCurrentStack((stack) => [...stack, newPanel]),
+    []
+  );
+  const removeFromPanelStack = React.useCallback(
+    () => setCurrentStack((stack) => stack.slice(0, -1)),
+    []
+  );
+
+  return (
+    <PanelStack2
+      className={props.className}
+      onOpen={addToPanelStack}
+      onClose={removeFromPanelStack}
+      renderActivePanelOnly={props.renderActivePanelOnly || true}
+      showPanelHeader={true}
+      stack={currentStack}
+    />
+  );
+}
+
+export { PanelStack };

--- a/packages/column-footprint-editor/src/components/index.ts
+++ b/packages/column-footprint-editor/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./map";

--- a/packages/column-footprint-editor/src/components/map/index.ts
+++ b/packages/column-footprint-editor/src/components/map/index.ts
@@ -1,0 +1,1 @@
+export * from "./mapgl";

--- a/packages/column-footprint-editor/src/components/map/map-pieces/add-geom.tsx
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/add-geom.tsx
@@ -1,0 +1,49 @@
+import React, { useContext, useState } from "react";
+import { AppContext } from "../../../context";
+import { Button, TextArea } from "@blueprintjs/core";
+import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
+import axios from "axios";
+import { base } from "../../../context/env";
+
+function PopoverContent({ addGeom }) {
+  const { state, runAction } = useContext(AppContext);
+
+  const [geom, setGeom] = useState("");
+
+  const onClick = async () => {
+    let url = base + "get-line";
+    let res = await axios.post(url, { location: geom });
+    let data = res.data;
+    let line = data["location"];
+    addGeom(line);
+  };
+
+  return (
+    <div className="add-geo-popover">
+      <h4 className="h4-0">Enter a WKT</h4>
+      <TextArea
+        onChange={(e) => setGeom(e.target.value)}
+        style={{ height: "150px" }}
+      />
+      <Button intent="success" onClick={onClick}>
+        Add
+      </Button>
+    </div>
+  );
+}
+
+export function AddKnownGeom({ addGeom }) {
+  return (
+    <div>
+      <Popover2
+        content={<PopoverContent addGeom={addGeom} />}
+        minimal={true}
+        placement="bottom-end"
+      >
+        <Tooltip2 content="Add Existing Geometry">
+          <Button rightIcon="shapes" />
+        </Tooltip2>
+      </Popover2>
+    </div>
+  );
+}

--- a/packages/column-footprint-editor/src/components/map/map-pieces/index.tsx
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/index.tsx
@@ -1,0 +1,91 @@
+export * from "./properties";
+export * from "./map-legend";
+export * from "./add-geom";
+export * from "./voronoi";
+import mapboxgl from "mapbox-gl";
+import { setWindowHash } from "../utils";
+import {
+  SnapLineMode,
+  MultVertDirectSelect,
+  MultVertSimpleSelect,
+  DrawPolyMult,
+} from "../modes";
+import MapboxDraw from "@mapbox/mapbox-gl-draw";
+import { SnapModeDrawStyles } from "mapbox-gl-draw-snap-mode";
+
+async function initializeMap(
+  mapContainerRef,
+  viewport,
+  addToChangeSet,
+  setViewport
+) {
+  var map = new mapboxgl.Map({
+    container: mapContainerRef,
+    style: "mapbox://styles/mapbox/streets-v11", // style URL
+    center: [viewport.longitude, viewport.latitude], // starting position [lng, lat]
+    zoom: viewport.zoom, // starting zoom
+  });
+
+  var nav = new mapboxgl.NavigationControl();
+
+  map.addControl(nav);
+
+  map.addToChangeSet = addToChangeSet;
+
+  map.on("move", () => {
+    const [zoom, latitude, longitude] = [
+      map.getZoom().toFixed(2),
+      map.getCenter().lat.toFixed(4),
+      map.getCenter().lng.toFixed(4),
+    ];
+    setViewport({ longitude, latitude, zoom });
+    setWindowHash({ zoom, latitude, longitude });
+  });
+  return map;
+}
+
+function editModeMap(map, state) {
+  /// draw.create, draw.delete, draw.update, draw.selectionchange
+  /// draw.modechange, draw.actionable, draw.combine, draw.uncombine
+  const Draw = new MapboxDraw({
+    controls: { point: false },
+    modes: Object.assign(
+      MapboxDraw.modes,
+      {
+        direct_select: MultVertDirectSelect,
+        simple_select: MultVertSimpleSelect,
+        draw_polygon: DrawPolyMult,
+      },
+      { draw_line_string: SnapLineMode }
+    ),
+    styles: SnapModeDrawStyles,
+    snap: true,
+    clickBuffer: 10,
+    snapOptions: {
+      snapPx: 25,
+    },
+  });
+
+  map.addControl(Draw, "top-left");
+
+  Draw.add(state.lines);
+  map.onDrawDelete = async function (e) {
+    const { type: action, features } = e;
+
+    features.map((feature) => {
+      const obj = { action, feature };
+      map.addToChangeSet(obj);
+    });
+  };
+
+  map.on("draw.delete", map.onDrawDelete);
+
+  map.switchToSimpleSelect = async function (e) {
+    Draw.changeMode("simple_select");
+  };
+
+  map.on("draw.update", map.switchToSimpleSelect);
+  return Draw;
+}
+
+export { initializeMap, editModeMap };

--- a/packages/column-footprint-editor/src/components/map/map-pieces/map-legend.tsx
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/map-legend.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+import { Tooltip2, Popover2 } from "@blueprintjs/popover2";
+import { Button, Divider } from "@blueprintjs/core";
+import { AddKnownGeom } from "./add-geom";
+
+function MapLegendRow(props) {
+  const { col_group, col_group_name, color } = props;
+  return (
+    <div className="map-legend-row">
+      <Tooltip2 content={<div>{col_group_name}</div>} placement="bottom-end">
+        <div style={{ display: "flex", alignItems: "baseline" }}>
+          <div
+            style={{
+              backgroundColor: color,
+              width: "10px",
+              height: "10px",
+              marginRight: "5px",
+            }}
+          ></div>
+          <div>{col_group}</div>
+        </div>
+      </Tooltip2>
+    </div>
+  );
+}
+
+function MapLegend({ columns }) {
+  let example_column = {
+    col_group: "Column Group",
+    col_group_name: "Column Group Name",
+    color: "#000000",
+  };
+  return (
+    <div className="map-legend-container">
+      <MapLegendRow {...example_column} />
+      <Divider />
+      {columns.map((column, i) => {
+        return <MapLegendRow key={i} {...column} />;
+      })}
+    </div>
+  );
+}
+
+function MapColLegend(props) {
+  const { columns } = props;
+
+  const [open, setOpen] = useState(true);
+
+  if (columns.length == 0) {
+    return <div></div>;
+  }
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Popover2
+          content={<MapLegend columns={columns} />}
+          minimal={true}
+          placement="bottom-end"
+        >
+          <Tooltip2 content="Column Legend">
+            <Button rightIcon="map" onClick={() => setOpen(!open)} />
+          </Tooltip2>
+        </Popover2>
+      </div>
+    </div>
+  );
+}
+
+function MapToolsControl(props) {
+  const { columns = [], editMode, addGeomToDraw } = props;
+
+  return (
+    <div>
+      {editMode ? (
+        <AddKnownGeom addGeom={addGeomToDraw} />
+      ) : (
+        <MapColLegend columns={columns} />
+      )}
+    </div>
+  );
+}
+
+export { MapColLegend, MapToolsControl };

--- a/packages/column-footprint-editor/src/components/map/map-pieces/properties.tsx
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/properties.tsx
@@ -1,0 +1,87 @@
+import { fetchProjColGroups } from "../../../context";
+import {
+  colorAttribute,
+  createMapboxPaintConditional,
+  addIdsToGeoJSON,
+} from "./utils";
+
+async function propertyViewMap(
+  map,
+  state,
+  features,
+  setFeatures,
+  setOpen,
+  setLegendColumns
+) {
+  let colGroups = await fetchProjColGroups(state.project.project_id);
+  colGroups = colorAttribute(colGroups);
+  setLegendColumns(colGroups);
+  let paintConditionals = createMapboxPaintConditional(colGroups);
+
+  let data = addIdsToGeoJSON(state.columns);
+
+  map.addSource("columns", {
+    type: "geojson",
+    data,
+  });
+  map.addLayer({
+    id: "column-fill",
+    type: "fill",
+    source: "columns", // reference the data source
+    paint: {
+      "fill-color": paintConditionals,
+      "fill-opacity": [
+        "case",
+        ["boolean", ["feature-state", "clicked"], false],
+        1,
+        0.3,
+      ],
+    },
+  });
+  map.addLayer({
+    id: "outline",
+    type: "line",
+    source: "columns",
+    layout: {},
+    paint: {
+      "line-color": "#000",
+      "line-width": 1,
+    },
+  });
+  map.on("mouseenter", "column-fill", async function(e) {
+    map.getCanvas().style.cursor = "pointer";
+  });
+  map.on("mouseleave", "column-fill", async function(e) {
+    map.getCanvas().style.cursor = "";
+  });
+
+  let highlightedFeature = null;
+  
+  if (features.length) {
+    highlightedFeature = features[0].id;
+    map.setFeatureState(
+      { source: "columns", id: highlightedFeature },
+      { clicked: true }
+    );
+  }
+
+  map.on("click", "column-fill", async function(e) {
+    if (e.features.length > 0) {
+      if (highlightedFeature !== null) {
+        map.setFeatureState(
+          { source: "columns", id: highlightedFeature },
+          { clicked: false }
+        );
+      }
+      highlightedFeature = e.features[0].id;
+      map.setFeatureState(
+        { source: "columns", id: highlightedFeature },
+        { clicked: true }
+      );
+    }
+    setFeatures(e.features);
+    setOpen(true);
+  });
+}
+
+export { propertyViewMap };

--- a/packages/column-footprint-editor/src/components/map/map-pieces/utils.tsx
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/utils.tsx
@@ -1,0 +1,38 @@
+export function randomColor() {
+  return "#" + ((Math.random() * 0xffffff) << 0).toString(16).padStart(6, "0");
+}
+
+export function colorAttribute(colGroups) {
+  let newColGroups = colGroups.map((col) => {
+    if (!col.color) {
+      let color = randomColor();
+      return { ...col, color };
+    }
+    return col;
+  });
+  return newColGroups;
+}
+
+export function createMapboxPaintConditional(colGroups) {
+  let predicate = [];
+  colGroups.map((col) => {
+    let color = col.color;
+    let id = col.id;
+    let pred = [["==", ["get", "col_group_id"], id], color];
+    predicate = [...predicate, ...pred];
+  });
+  return [
+    "case",
+    ...predicate,
+    ["==", ["get", "col_group_id"], null],
+    "#F95E5E",
+    "#0BDCB9",
+  ];
+}
+
+export function addIdsToGeoJSON(columns) {
+  let features = columns.features.map((feature, i) => {
+    return { id: i, ...feature };
+  });
+  return { type: "FeatureCollection", features };
+}

--- a/packages/column-footprint-editor/src/components/map/map-pieces/voronoi.ts
+++ b/packages/column-footprint-editor/src/components/map/map-pieces/voronoi.ts
@@ -1,0 +1,69 @@
+import MapboxDraw from "@mapbox/mapbox-gl-draw";
+import { PointsOnly } from "../modes";
+
+function voronoiModeMap(
+  map,
+  polygons,
+  points,
+  lines,
+  addVoronoiPoint,
+  moveVoronoiPoint,
+  deleteVoronoiPoint
+) {
+  const modes = Object.assign(MapboxDraw.modes, {
+    simple_select: PointsOnly,
+  });
+
+  const Draw = new MapboxDraw({
+    controls: {
+      polygon: false,
+      line_string: false,
+      trash: true,
+      combine_features: false,
+      uncombine_features: false,
+    },
+    modes,
+  });
+
+  map.addControl(Draw, "top-left");
+
+  if (polygons?.length ?? false) {
+    Draw.add({ type: "FeatureCollection", features: polygons });
+  }
+  if (lines) {
+    Draw.add(lines);
+  }
+  if (points) {
+    Draw.add({ type: "FeatureCollection", features: points });
+  }
+
+  map.addVoronoiPoint = async function (e) {
+    const feature = e.features[0];
+    const type = feature.geometry.type;
+    if (type == "Point") {
+      addVoronoiPoint(feature);
+    }
+  };
+  map.moveVoronoiPoint = async function (e) {
+    const feature = e.features[0];
+    const type = feature.geometry.type;
+    if (type == "Point") {
+      moveVoronoiPoint(feature);
+    }
+  };
+
+  map.deleteVoronoiPoint = async function (e) {
+    const feature = e.features[0];
+    const type = feature.geometry.type;
+    if (type == "Point") {
+      deleteVoronoiPoint(feature);
+    }
+  };
+
+  map.on("draw.create", map.addVoronoiPoint);
+  map.on("draw.delete", map.deleteVoronoiPoint);
+  map.on("draw.update", map.moveVoronoiPoint);
+  return Draw;
+}
+
+export { voronoiModeMap };

--- a/packages/column-footprint-editor/src/components/map/map.css
+++ b/packages/column-footprint-editor/src/components/map/map.css
@@ -1,0 +1,35 @@
+@import "~/node_modules/@blueprintjs/core/lib/css/blueprint.css";
+@import "~/node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css";
+@import "~/node_modules/@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+
+.map-container {
+  position: absolute;
+  top: 50px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.map-legend-container {
+  padding: 10px;
+}
+
+.add-geo-popover {
+  padding: 10px;
+  height: 250px;
+  width: 250px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.map-tools-control-right {
+  position: absolute;
+  top: 160px;
+  right: 9px;
+}
+.map-tools-control-left {
+  position: absolute;
+  top: 210px;
+  left: 9px;
+}

--- a/packages/column-footprint-editor/src/components/map/mapgl.tsx
+++ b/packages/column-footprint-editor/src/components/map/mapgl.tsx
@@ -1,0 +1,289 @@
+import "regenerator-runtime/runtime";
+import React, { useRef, useEffect, useState, useContext } from "react";
+import "mapbox-gl/dist/mapbox-gl.css";
+import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+import mapboxgl from "mapbox-gl";
+import { AppContext, ChangeSetItem } from "../../context";
+import { MapNavBar, AppToaster } from "../blueprint";
+import { PropertyDialog } from "../editor";
+import { ImportDialog } from "../importer";
+import { locationFromHash } from "./utils";
+import "./map.css";
+import {
+  initializeMap,
+  propertyViewMap,
+  editModeMap,
+  MapToolsControl,
+  voronoiModeMap,
+} from "./map-pieces";
+import { VoronoiToolBar } from "../voronoi/tool-bar";
+import { mapboxToken } from "../../context/env";
+import { MAP_MODES, VoronoiPoint } from "../../context";
+
+/**
+ *
+ * For delete point, feature.removeCoordinate()
+ *
+ *
+ * For the "preview" mode. Add layer, fill will be based on property. Hover would be nice touch. Then popup
+ *
+ */
+
+mapboxgl.accessToken = mapboxToken;
+
+export function Map() {
+  const mapContainerRef = useRef(null);
+  const mapRef = useRef();
+  const drawRef = useRef();
+  const voronoiRef = useRef();
+
+  const { state, runAction, updateLinesAndColumns } = useContext(AppContext);
+  const { mode, changeSet } = state;
+
+  const [viewport, setViewport] = useState(
+    locationFromHash(window.location.hash)
+  );
+  const [legendColumns, setLegendColumns] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [features, setFeatures] = useState([]);
+
+  const closeOpen = () => {
+    setFeatures([]);
+    setOpen(false);
+  };
+
+  const changeMode = (mode: MAP_MODES) => {
+    runAction({ type: "set-map-mode", mode });
+  };
+
+  const addToChangeSet = (obj: ChangeSetItem) => {
+    runAction({ type: "add-to-changeset", item: obj });
+  };
+
+  const onSave = async () => {
+    if (changeSet.length != 0 && mode != MAP_MODES.voronoi) {
+      runAction({
+        type: "save-changeset",
+        changeSet: state.changeSet,
+        project_id: state.project.project_id ?? 0,
+      });
+    } else if (mode == MAP_MODES.voronoi) {
+      /// persist new polygons to db
+      runAction({
+        type: "save-voronoi",
+        project_id: state.project.project_id ?? 0,
+        voronoiState: state.voronoi,
+      });
+    }
+  };
+
+  const onCancel = () => {
+    AppToaster.show({
+      message: "Undoing all Changes...",
+      intent: "warning",
+      timeout: 1000,
+    });
+    updateLinesAndColumns(state.project.project_id);
+  };
+
+  useEffect(() => {
+    if (mapContainerRef.current == null) return;
+    initializeMap(
+      mapContainerRef.current,
+      viewport,
+      addToChangeSet,
+      setViewport
+    ).then((mapObj) => {
+      mapRef.current = mapObj;
+    });
+    return () => {
+      mapRef.current.remove();
+    };
+  }, [mapContainerRef]);
+
+  useEffect(() => {
+    if (mapRef.current == null) return;
+    const edit = mode == MAP_MODES.topology;
+    if (edit) {
+      const map = mapRef.current;
+
+      let draw = editModeMap(map, state);
+      drawRef.current = draw;
+      return () => {
+        let map = mapRef.current;
+        let Draw = drawRef.current;
+        if (!map || !Draw || !edit) return;
+        try {
+          map.off("draw.update", map.switchToSimpleSelect);
+          map.off("draw.delete", map.onDrawDelete);
+          Draw.onRemove();
+        } catch (error) {
+          console.log(error);
+        }
+      };
+    }
+  }, [state.lines, mode, mapRef]);
+
+  const addVoronoiPoint = (point: object) => {
+    runAction({
+      type: "fetch-voronoi-state",
+      points: state.voronoi.points ?? [],
+      point,
+      project_id: state.project.project_id ?? 0,
+      radius: state.voronoi.radius,
+      quad_segs: state.voronoi.quad_seg,
+    });
+  };
+  const moveVoronoiPoint = (point: VoronoiPoint) => {
+    let filteredPoints = state.voronoi.points?.filter((p) => p.id != point.id);
+
+    filteredPoints = filteredPoints ?? [];
+    filteredPoints = [...filteredPoints, point];
+    runAction({
+      type: "fetch-voronoi-state",
+      points: filteredPoints,
+      point: null,
+      project_id: state.project.project_id ?? 0,
+      radius: state.voronoi.radius,
+      quad_segs: state.voronoi.quad_seg,
+    });
+  };
+
+  const deleteVoronoiPoint = (point: VoronoiPoint) => {
+    const filteredPoints =
+      state.voronoi.points?.filter((p) => p.id != point.id) ?? [];
+
+    runAction({
+      type: "fetch-voronoi-state",
+      points: filteredPoints,
+      point: null,
+      project_id: state.project.project_id ?? 0,
+      radius: state.voronoi.radius,
+      quad_segs: state.voronoi.quad_seg,
+    });
+  };
+
+  useEffect(() => {
+    if (mapRef.current == null) return;
+    const isVoronoiMode = mode == MAP_MODES.voronoi;
+    if (isVoronoiMode) {
+      const map = mapRef.current;
+      let draw = voronoiModeMap(
+        map,
+        state.voronoi.polygons,
+        state.voronoi.points,
+        state.lines,
+        addVoronoiPoint,
+        moveVoronoiPoint,
+        deleteVoronoiPoint
+      );
+      voronoiRef.current = draw;
+      return () => {
+        let map = mapRef.current;
+        let Draw = voronoiRef.current;
+        if (!map || !Draw || !isVoronoiMode) return;
+        try {
+          map.off("draw.create", map.addVoronoiPoint);
+          map.off("draw.update", map.moveVoronoiPoint);
+          map.off("draw.delete", map.deleteVoronoiPoint);
+          Draw.onRemove();
+        } catch (error) {
+          console.log(error);
+        }
+      };
+    }
+  }, [
+    mode,
+    mapRef,
+    state.voronoi.polygons,
+    state.voronoi.quad_seg,
+    state.voronoi.radius,
+    state.lines,
+  ]);
+
+  useEffect(() => {
+    if (mapRef.current == null) return;
+    if (mode == MAP_MODES.properties) {
+      propertyViewMap(
+        mapRef.current,
+        state,
+        features,
+        setFeatures,
+        setOpen,
+        setLegendColumns
+      );
+      return () => {
+        var mapLayer = mapRef.current.getLayer("column-fill");
+        if (typeof mapLayer !== "undefined") {
+          mapRef.current.removeLayer("column-fill");
+          mapRef.current.removeLayer("outline");
+          mapRef.current.removeSource("columns");
+        }
+      };
+    }
+  }, [state.columns, mode, mapRef]);
+
+  const mapToolsClassName =
+    mode == MAP_MODES.topology
+      ? "map-tools-control-left"
+      : "map-tools-control-right";
+
+  const addGeomToDraw = (geom) => {
+    const draw = drawRef.current;
+    if (typeof draw === "undefined") return;
+    let feature = draw.add(geom);
+
+    const obj = {
+      action: "draw.create",
+      feature: { type: "Feature", id: feature[0], geometry: geom },
+    };
+
+    addToChangeSet(obj);
+  };
+
+  return (
+    <div>
+      <ImportDialog />
+      <div>
+        <MapNavBar
+          onSave={onSave}
+          onCancel={onCancel}
+          changeMode={changeMode}
+          mode={mode}
+          project_id={state.project.project_id}
+          polygons={state.voronoi.polygons}
+          changeSet={changeSet}
+        />
+      </div>
+      <VoronoiToolBar
+        runAction={runAction}
+        quad_segs={state.voronoi.quad_seg}
+        radius={state.voronoi.radius}
+        mode={mode}
+      />
+
+      <div>
+        <div className="map-container" ref={mapContainerRef} />
+      </div>
+      <div className={mapToolsClassName}>
+        <MapToolsControl
+          addGeomToDraw={addGeomToDraw}
+          columns={legendColumns}
+          editMode={mode == MAP_MODES.topology}
+        />
+      </div>
+      {mode == MAP_MODES.topology ? null : (
+        <div>
+          <PropertyDialog
+            open={open}
+            features={features}
+            setFeatures={setFeatures}
+            closeOpen={closeOpen}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const M = "Mapbobgl";

--- a/packages/column-footprint-editor/src/components/map/modes/direct-select-mult.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/direct-select-mult.ts
@@ -1,0 +1,132 @@
+import "regenerator-runtime/runtime";
+import DirectSelect from "@mapbox/mapbox-gl-draw/src/modes/direct_select";
+import "mapbox-gl/dist/mapbox-gl.css";
+import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+import doubleClickZoom from "@mapbox/mapbox-gl-draw/src/lib/double_click_zoom";
+import * as Constants from "@mapbox/mapbox-gl-draw/src/constants";
+
+const MultVertDirectSelect = { ...DirectSelect };
+
+MultVertDirectSelect.onSetup = function (opts) {
+  const featureId = opts.featureId;
+  const feature = this.getFeature(featureId);
+
+  const toMoveFeatures = opts.toMoveFeatures;
+  const toMoveCoordPaths = opts.toMoveCoordPaths;
+  const movedCoordPath = opts.movedCoordPath;
+
+  if (!feature) {
+    throw new Error("You must provide a featureId to enter direct_select mode");
+  }
+
+  if (feature.type === Constants.geojsonTypes.POINT) {
+    throw new TypeError("direct_select mode doesn't handle point features");
+  }
+
+  const state = {
+    featureId,
+    feature,
+    dragMoveLocation: opts.startPos || null,
+    dragMoving: false,
+    canDragMove: false,
+    selectedCoordPaths: opts.coordPath ? [opts.coordPath] : [],
+    movedCoordPath,
+    toMoveCoordPaths,
+    toMoveFeatures,
+    newCoord: undefined,
+  };
+
+  this.setSelectedCoordinates(
+    this.pathsToCoordinates(featureId, state.selectedCoordPaths)
+  );
+  this.setSelected(featureId);
+  doubleClickZoom.disable(this);
+
+  this.setActionableState({
+    trash: true,
+  });
+
+  return state;
+};
+
+MultVertDirectSelect.onDrag = function (state, e) {
+  if (state.canDragMove !== true) return;
+  state.dragMoving = true;
+  e.originalEvent.stopPropagation();
+
+  const delta = {
+    lng: e.lngLat.lng - state.dragMoveLocation.lng,
+    lat: e.lngLat.lat - state.dragMoveLocation.lat,
+  };
+  if (state.selectedCoordPaths.length > 0) this.dragVertex(state, e, delta);
+
+  state.dragMoveLocation = e.lngLat;
+
+  let newCoord = [e.lngLat.lng, e.lngLat.lat];
+  state.newCoord = newCoord;
+  // different features, works for more than 2 shared vertices
+  // now lists of line strings
+  if (state.toMoveFeatures) {
+    state.toMoveFeatures.map((feature, index) => {
+      const path = state.toMoveCoordPaths[index];
+      let [lng, lat] = newCoord;
+      feature.updateCoordinate(path, lng, lat);
+    });
+  }
+};
+
+/**
+ * Helper function to add a feature coordinate change to changeset
+ * @param feature valid mapbox feature
+ */
+MultVertDirectSelect.onDragChangeSetAdder = function (feature) {
+  const action = Constants.updateActions.CHANGE_COORDINATES;
+  const obj = {
+    action,
+    feature: feature.toGeoJSON(),
+  };
+  this.map.addToChangeSet(obj);
+};
+
+MultVertDirectSelect.onStop = function (state) {
+  if (state.movedCoordPath && state.newCoord) {
+    // different features, works for more than 2 shared vertices
+    state.toMoveFeatures.map((feature, index) => {
+      let path = state.toMoveCoordPaths[index];
+      let [lng, lat] = state.newCoord;
+      feature.updateCoordinate(path, lng, lat);
+      this.onDragChangeSetAdder(feature);
+    });
+  } else {
+    this.onDragChangeSetAdder(state.feature);
+  }
+  doubleClickZoom.enable(this);
+  this.clearSelectedCoordinates();
+};
+
+MultVertDirectSelect.onTrash = function (state) {
+  // Uses number-aware sorting to make sure '9' < '10'. Comparison is reversed because we want them
+  // in reverse order so that we can remove by index safely.
+  if (!state.toMoveCoordPaths) {
+    //no shared vertices
+    state.selectedCoordPaths
+      .sort((a, b) => b.localeCompare(a, "en", { numeric: true }))
+      .forEach((id) => {
+        state.feature.removeCoordinate(id);
+      });
+    this.fireUpdate();
+    state.selectedCoordPaths = [];
+    this.clearSelectedCoordinates();
+    this.fireActionable(state);
+    if (state.feature.isValid() === false) {
+      this.deleteFeature([state.featureId]);
+      this.changeMode(Constants.modes.SIMPLE_SELECT, {});
+    }
+  } else {
+    /// we only want to delete the one point..
+    const pointId = state.selectedCoordPaths[0];
+    state.feature.removeCoordinate(pointId);
+  }
+};
+
+export { MultVertDirectSelect };

--- a/packages/column-footprint-editor/src/components/map/modes/draw-polygon.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/draw-polygon.ts
@@ -1,0 +1,122 @@
+import * as CommonSelectors from "@mapbox/mapbox-gl-draw/src/lib/common_selectors";
+import {
+  geojsonTypes,
+  meta,
+  activeStates,
+} from "@mapbox/mapbox-gl-draw/src/constants";
+import doubleClickZoom from "@mapbox/mapbox-gl-draw/src/lib/double_click_zoom";
+import DrawPolygon from "@mapbox/mapbox-gl-draw/src/modes/draw_polygon";
+import "mapbox-gl/dist/mapbox-gl.css";
+import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+import * as Constants from "@mapbox/mapbox-gl-draw/src/constants";
+import { distance_between_points } from "../utils";
+
+let DrawPolyMult = { ...DrawPolygon };
+
+DrawPolyMult.onSetup = function (opts) {
+  const line = this.newFeature({
+    type: geojsonTypes.FEATURE,
+    properties: {},
+    geometry: {
+      type: geojsonTypes.MULTI_LINE_STRING,
+      coordinates: [[]],
+    },
+  });
+
+  this.addFeature(line);
+
+  this.clearSelectedFeatures();
+  doubleClickZoom.disable(this);
+
+  return { line, canDraw: false, n: 6 };
+};
+
+DrawPolyMult.createNPolygon = function (x, y, n, r) {
+  // n is number of sides
+  // x is the xoffset
+  // y is the yoffset
+  // r is radius
+
+  const polygon: number[][] = [];
+
+  for (let i = 0; i <= n; i++) {
+    const pointX = r * Math.cos(i * ((2 * Math.PI) / n)) + x;
+    const pointY = r * Math.sin(i * ((2 * Math.PI) / n)) + y;
+    const { lng, lat }: { lng: number; lat: number } = this.map.unproject([
+      pointX,
+      pointY,
+    ]);
+    polygon.push([lng, lat]);
+  }
+  return [polygon];
+};
+
+DrawPolyMult.onMouseMove = function (state, e) {
+  if (!state.canDraw) return;
+
+  const { n } = state;
+  const { x, y } = state.centerPoint;
+
+  const buffer =
+    distance_between_points({ point1: e.point, point2: state.centerPoint }) +
+    10;
+
+  const bbox = this.createNPolygon(x, y, n, buffer);
+
+  state.line.setCoordinates(bbox);
+};
+
+DrawPolyMult.clickAnywhere = function (state, e) {
+  state.canDraw = true;
+  state.centerPoint = e.point;
+};
+
+DrawPolyMult.onKeyUp = function (state, e) {
+  if (CommonSelectors.isEscapeKey(e)) {
+    this.deleteFeature([state.line.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
+  } else if (CommonSelectors.isEnterKey(e)) {
+    this.changeMode(Constants.modes.SIMPLE_SELECT);
+  } else {
+    if (e.key == "a") {
+      state.n += 1;
+    } else if (e.key == "s" && state.n > 3) {
+      state.n -= 1;
+    }
+  }
+};
+
+DrawPolyMult.onStop = function (state) {
+  this.updateUIClasses({ mouse: Constants.cursors.NONE });
+  doubleClickZoom.enable(this);
+  this.activateUIButton();
+
+  // check to see if we've deleted this feature
+  if (this.getFeature(state.line.id) === undefined) return;
+
+  //remove last added coordinate
+  if (state.line.isValid()) {
+    this.map.fire(Constants.events.CREATE, {
+      features: [state.line.toGeoJSON()],
+    });
+    const obj = {
+      action: "draw.create",
+      feature: state.line.toGeoJSON(),
+    };
+    this.map.addToChangeSet(obj);
+  } else {
+    this.deleteFeature([state.line.id], { silent: true });
+    this.changeMode(Constants.modes.SIMPLE_SELECT, {}, { silent: true });
+  }
+};
+
+DrawPolyMult.toDisplayFeatures = function (state, geojson, display) {
+  const isActiveLine = geojson.properties.id === state.line.id;
+  geojson.properties.active = isActiveLine
+    ? activeStates.ACTIVE
+    : activeStates.INACTIVE;
+  geojson.properties.meta = meta.FEATURE;
+  display(geojson);
+};
+
+export { DrawPolyMult };

--- a/packages/column-footprint-editor/src/components/map/modes/index.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/index.ts
@@ -1,0 +1,5 @@
+export * from "./snap-line-draw";
+export * from "./simple-select-mult";
+export * from "./direct-select-mult";
+export * from "./draw-polygon";
+export * from "./points-only";

--- a/packages/column-footprint-editor/src/components/map/modes/points-only.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/points-only.ts
@@ -1,0 +1,20 @@
+import "regenerator-runtime/runtime";
+import SimpleSelect from "@mapbox/mapbox-gl-draw/src/modes/simple_select";
+import "mapbox-gl/dist/mapbox-gl.css";
+import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+
+const PointsOnly = { ...SimpleSelect };
+
+PointsOnly.clickOnFeature = function (state, e) {
+  if (e.featureTarget.geometry.type !== "Point") {
+    return;
+  }
+  SimpleSelect.clickOnFeature.call(this, state, e);
+};
+
+// need to just pass off it there aren't other verticies at point
+PointsOnly.clickOnVertex = function (state, e) {
+  return;
+};
+
+export { PointsOnly };

--- a/packages/column-footprint-editor/src/components/map/modes/simple-select-mult.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/simple-select-mult.ts
@@ -1,0 +1,115 @@
+import "regenerator-runtime/runtime";
+import SimpleSelect from "@mapbox/mapbox-gl-draw/src/modes/simple_select";
+import "mapbox-gl/dist/mapbox-gl.css";
+import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
+import * as Constants from "@mapbox/mapbox-gl-draw/src/constants";
+import * as CommonSelectors from "@mapbox/mapbox-gl-draw/src/lib/common_selectors";
+
+import { distance_between_points } from "../utils";
+
+const MultVertSimpleSelect = { ...SimpleSelect };
+
+MultVertSimpleSelect.onSetup = function (opts) {
+  // turn the opts into state.
+  const state = {
+    dragMoveLocation: null,
+    boxSelectStartLocation: null,
+    boxSelectElement: undefined,
+    boxSelecting: false,
+    canBoxSelect: false,
+    dragMoving: false,
+    canDragMove: false,
+    initiallySelectedFeatureIds: opts.featureIds || [],
+    movedCoordPath: undefined,
+    toMoveCoordPaths: undefined,
+    toMoveFeatures: undefined,
+  };
+
+  this.setSelected(
+    state.initiallySelectedFeatureIds.filter(
+      (id) => this.getFeature(id) !== undefined
+    )
+  );
+  this.fireActionable();
+
+  this.setActionableState({
+    combineFeatures: true,
+    uncombineFeatures: true,
+    trash: true,
+  });
+
+  return state;
+};
+
+MultVertSimpleSelect.fireUpdate = function () {
+  this.getSelected().map((f) => {
+    const action = Constants.updateActions.CHANGE_COORDINATES;
+    const obj = {
+      action,
+      feature: f.toGeoJSON(),
+    };
+    this.map.addToChangeSet(obj);
+  });
+  this.map.fire(Constants.events.UPDATE, {
+    action: Constants.updateActions.MOVE,
+    features: this.getSelected().map((f) => f.toGeoJSON()),
+  });
+};
+
+// need to just pass off it there aren't other verticies at point
+MultVertSimpleSelect.clickOnVertex = function (state, e) {
+  const isShiftClick = CommonSelectors.isShiftDown(e);
+  if (isShiftClick) {
+    this.changeMode("direct_select", {
+      featureId: e.featureTarget.properties.parent,
+      coordPath: e.featureTarget.properties.coord_path,
+      startPos: e.lngLat,
+      toMoveFeatures: state.toMoveFeatures,
+      toMoveCoordPaths: state.toMoveCoordPaths,
+      movedCoordPath: state.movedCoordPath,
+    });
+    return;
+  }
+
+  // this block gets features other than the clicked one at point
+  var point = this.map.project(e.lngLat);
+  const idsAtPoint = this._ctx.api.getFeatureIdsAt(point);
+  let features = idsAtPoint.map((id) => this.getFeature(id));
+  features = features.filter((f) => f != null); // this will return the other vertix
+  if (features.length > 0) {
+    state.movedCoordPath = e.featureTarget.properties.coord_path; // "0.5" might mean first feature 4th point
+    let match: string[] = [];
+    let movingFeatures: any = []; // feature type
+    features.map((fs) => {
+      // multiline string
+      fs.features.map((f, lineIndex) => {
+        // f is a linestring, line_index is which line in the multilinestring!
+        if (f) {
+          f.coordinates.map((coord, pointIndex) => {
+            let point1 = this.map.project(coord);
+            if (
+              distance_between_points({ point1: point, point2: point1 }) < 10
+            ) {
+              match.push(`${lineIndex}.${pointIndex}`);
+              movingFeatures.push(fs);
+            }
+          });
+        }
+      });
+    });
+    state.toMoveCoordPaths = match;
+    state.toMoveFeatures = movingFeatures;
+  }
+
+  // this is what the normal simple_select does, we want to keep that the same
+  this.changeMode("direct_select", {
+    featureId: e.featureTarget.properties.parent,
+    coordPath: e.featureTarget.properties.coord_path,
+    startPos: e.lngLat,
+    toMoveFeatures: state.toMoveFeatures,
+    toMoveCoordPaths: state.toMoveCoordPaths,
+    movedCoordPath: state.movedCoordPath,
+  });
+};
+
+export { MultVertSimpleSelect };

--- a/packages/column-footprint-editor/src/components/map/modes/snap-line-draw.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/snap-line-draw.ts
@@ -1,0 +1,160 @@
+//import { SnapLineMode, SnapModeDrawStyles } from "mapbox-gl-draw-snap-mode";
+
+import {
+  geojsonTypes,
+  activeStates,
+  meta,
+  cursors,
+} from "@mapbox/mapbox-gl-draw/src/constants";
+import doubleClickZoom from "@mapbox/mapbox-gl-draw/src/lib/double_click_zoom";
+import DrawLine from "@mapbox/mapbox-gl-draw/src/modes/draw_line_string";
+import {
+  addPointTovertices,
+  createSnapList,
+} from "mapbox-gl-draw-snap-mode/src/utils";
+import createVertex from "@mapbox/mapbox-gl-draw/src/lib/create_vertex";
+import {
+  createPointOnLine,
+  incrementMultiPath,
+  parseMultiPath,
+  snapToCoord,
+} from "./utils";
+
+const SnapLineMode = { ...DrawLine };
+
+SnapLineMode.onSetup = function (opts) {
+  const line = this.newFeature({
+    type: geojsonTypes.FEATURE,
+    properties: {},
+    geometry: {
+      type: geojsonTypes.MULTI_LINE_STRING,
+      coordinates: [[]],
+    },
+  });
+
+  this.addFeature(line);
+
+  const selectedFeatures = this.getSelected();
+  this.clearSelectedFeatures();
+  doubleClickZoom.disable(this);
+
+  const [snapList, vertices] = createSnapList(this.map, this._ctx.api, line);
+
+  const state = {
+    map: this.map,
+    line,
+    currentVertexPosition: "0.0",
+    vertices,
+    snapList,
+    selectedFeatures,
+    direction: "forward", // expected by DrawLineString
+  };
+
+  state.options = this._ctx.options;
+
+  const moveendCallback = () => {
+    const [snapList, vertices] = createSnapList(this.map, this._ctx.api, line);
+    state.vertices = vertices;
+    state.snapList = snapList;
+  };
+  // for removing listener later on close
+  state["moveendCallback"] = moveendCallback;
+
+  const optionsChangedCallBAck = (options) => {
+    state.options = options;
+  };
+  // for removing listener later on close
+  state["optionsChangedCallBAck"] = optionsChangedCallBAck;
+
+  this.map.on("moveend", moveendCallback);
+  this.map.on("draw.snap.options_changed", optionsChangedCallBAck);
+
+  return state;
+};
+
+SnapLineMode.clickAnywhere = function (state, e) {
+  const lng = state.snappedLng;
+  const lat = state.snappedLat;
+
+  addPointTovertices(state.map, state.vertices, [lng, lat]);
+
+  var point = this.map.project({ lng, lat });
+  const idsAtPoint = this._ctx.api.getFeatureIdsAt(point);
+  const filteredIds = idsAtPoint.filter((id) => id != state.line.id);
+  createPointOnLine(filteredIds, [lng, lat], this);
+
+  state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
+
+  state.currentVertexPosition = incrementMultiPath(state.currentVertexPosition);
+
+  state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
+};
+
+SnapLineMode.onMouseMove = function (state, e) {
+  const [lng, lat] = snapToCoord(state, e, this.map);
+
+  state.line.updateCoordinate(state.currentVertexPosition, lng, lat);
+  state.snappedLng = lng;
+  state.snappedLat = lat;
+
+  if (
+    state.lastVertex &&
+    state.lastVertex[0] === lng &&
+    state.lastVertex[1] === lat
+  ) {
+    this.updateUIClasses({ mouse: cursors.POINTER });
+  } else {
+    this.updateUIClasses({ mouse: cursors.ADD });
+  }
+};
+
+// This is 'extending' DrawLine.toDisplayFeatures
+SnapLineMode.toDisplayFeatures = function (state, geojson, display) {
+  const isActiveLine = geojson.properties.id === state.line.id;
+  geojson.properties.active = isActiveLine
+    ? activeStates.ACTIVE
+    : activeStates.INACTIVE;
+  if (!isActiveLine) return display(geojson);
+
+  const [line, path] = parseMultiPath(state.currentVertexPosition);
+
+  // Only render the line if it has at least one real coordinate
+  if (geojson.geometry.coordinates[line].length < 2) return;
+  geojson.properties.meta = meta.FEATURE;
+
+  display(
+    createVertex(
+      //parentId, coordinates, path, selected
+      state.line.id,
+      geojson.geometry.coordinates[line][
+        state.direction === "forward"
+          ? geojson.geometry.coordinates[line].length - 2
+          : 1
+      ],
+      `${line}.${
+        state.direction === "forward"
+          ? geojson.geometry.coordinates[line].length - 2
+          : 1
+      }`,
+      false
+    )
+  );
+
+  display(geojson);
+};
+
+// This is 'extending' DrawLine.onStop
+SnapLineMode.onStop = function (state) {
+  // remove moveemd callback
+  this.map.off("moveend", state.moveendCallback);
+  this.map.off("draw.snap.options_changed", state.optionsChangedCallBAck);
+
+  DrawLine.onStop.call(this, state);
+  const obj = {
+    action: "draw.create",
+    feature: state.line.toGeoJSON(),
+  };
+  this.map.addToChangeSet(obj);
+};
+
+export { SnapLineMode };

--- a/packages/column-footprint-editor/src/components/map/modes/utils.ts
+++ b/packages/column-footprint-editor/src/components/map/modes/utils.ts
@@ -1,0 +1,126 @@
+import * as Constants from "@mapbox/mapbox-gl-draw/src/constants";
+import nearestPointOnLine from "@turf/nearest-point-on-line";
+import { distance_between_points } from "../utils";
+
+function getClosestLine(lines, point, map) {
+  lines = lines.filter((geom) => geom.geometry.type != "Point");
+  if (lines.length == 0) {
+    return { geometry: { coordinates: point } };
+  }
+  let closest;
+  const pixelPoint = map.project(point);
+  let minDis = null;
+  lines.map((line) => {
+    const newPoint = nearestPointOnLine(line, point);
+    if (newPoint.properties.dist == Infinity) {
+      return point;
+    }
+    const newPixelPoint = map.project(newPoint.geometry.coordinates);
+
+    const dist = distance_between_points({
+      point1: pixelPoint,
+      point2: newPixelPoint,
+    });
+
+    if (!minDis && dist <= 40) {
+      minDis = dist;
+      closest = newPoint;
+    } else if (dist < minDis && dist <= 40) {
+      minDis = dist;
+      closest = newPoint;
+    }
+  });
+  if (closest) {
+    return closest;
+  } else {
+    const point_ = { geometry: { coordinates: point } };
+    return point_;
+  }
+}
+
+function snapToCoord(state, e, map) {
+  let lng = e.lngLat.lng;
+  let lat = e.lngLat.lat;
+
+  const closestPoint = getClosestLine(state.snapList, [lng, lat], map).geometry
+    .coordinates;
+  const [lng_, lat_] = closestPoint;
+
+  return [lng_, lat_];
+}
+
+function parseMultiPath(path: string): number[] {
+  let nums: number[] = path.split(".").map((str) => parseInt(str));
+  return nums;
+}
+
+function incrementMultiPath(path: string, inc = true): string {
+  let [line, path_] = parseMultiPath(path);
+  if (inc) {
+    path_++;
+  } else {
+    path_--;
+  }
+  return `${line}.${path_}`;
+}
+
+function pointBetweenPoints(bound1, bound2, point) {
+  /// checks if the point is inbetween two points
+  /// If the point is on the line made from the two points
+  // it will return true
+  const [x1, y1] = bound1;
+  const [x2, y2] = bound2;
+  const [xn, yn] = point;
+  const xMax = Math.max.apply(Math, [x1, x2]);
+  const xMin = Math.min.apply(Math, [x1, x2]);
+  const yMax = Math.max.apply(Math, [y1, y2]);
+  const yMin = Math.min.apply(Math, [y1, y2]);
+
+  if (xn < xMax && xn > xMin && yn < yMax && yn > yMin) {
+    return true;
+  }
+  return false;
+}
+
+const onChangeSetAdder = function (feature, this_) {
+  const action = Constants.updateActions.CHANGE_COORDINATES;
+  const obj = {
+    action,
+    feature: feature.toGeoJSON(),
+  };
+  this_.map.addToChangeSet(obj);
+};
+
+function createPointOnLine(ids, point, map) {
+  const [lng, lat] = point;
+  let lineIndex;
+  let pointIndex;
+  ids.map((id) => {
+    const feature = map.getFeature(id);
+    feature.features.map((f, lineIndex_) => {
+      if (f) {
+        const coordinates = f.coordinates;
+        if (coordinates.length == 2) {
+          // line segment
+          f.addCoordinate(1, lng, lat);
+          onChangeSetAdder(feature, map);
+        }
+        coordinates.map((coord, i) => {
+          if (i <= coordinates.length - 2) {
+            const bound1 = coordinates[i];
+            const bound2 = coordinates[i + 1];
+            if (pointBetweenPoints(bound1, bound2, point)) {
+              pointIndex = i + 1;
+              lineIndex = lineIndex_;
+              const path = `${lineIndex}.${pointIndex}`;
+              feature.addCoordinate(path, lng, lat);
+              onChangeSetAdder(feature, map);
+            }
+          }
+        });
+      }
+    });
+  });
+}
+
+export { snapToCoord, parseMultiPath, incrementMultiPath, createPointOnLine };

--- a/packages/column-footprint-editor/src/components/map/utils.ts
+++ b/packages/column-footprint-editor/src/components/map/utils.ts
@@ -1,0 +1,108 @@
+import * as topojson from "topojson-client";
+
+function TopoJSONToLineString(json) {
+  const multiLineString = topojson.mesh(json);
+
+  const lines = multiLineString.coordinates;
+
+  const features = lines.map((line) => {
+    const lineString = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: line,
+      },
+    };
+
+    return lineString;
+  });
+
+  const featureCollection = {
+    type: "FeatureCollection",
+    features: features,
+  };
+  return featureCollection;
+}
+
+/**
+ * Would be better if I could do it based on pixel distance
+ * Function tells whether too coordinates are the same or not
+ * @param props
+ * coord1:  [lng, lat]
+ * coord2: [lng,lat]
+ *
+ *
+ * @returns boolean
+ */
+function coordinatesAreEqual(props) {
+  const { coord1, coord2 } = props;
+  if (
+    coord1[0].toFixed(1) == coord2[0].toFixed(1) &&
+    coord1[1].toFixed(1) == coord2[1].toFixed(1)
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Function to find distance between two points, using pixel distance
+ * and basic geometry
+ * @param props
+ * @returns
+ */
+function distance_between_points(props) {
+  const { point1, point2 } = props;
+  let x1 = point1.x;
+  let x2 = point2.x;
+
+  let y1 = point1.y;
+  let y2 = point2.y;
+
+  let a = Math.pow(x2 - x1, 2);
+  let b = Math.pow(y2 - y1, 2);
+
+  return Math.sqrt(a + b);
+}
+
+function isOnOtherVertix(currentVertix, vertices) {
+  let match = [];
+  vertices.map((vertex) => {
+    if (Array.isArray(vertex)) {
+      if (coordinatesAreEqual({ coord1: currentVertix, coord2: vertex })) {
+        match.push(1);
+      }
+    }
+  });
+  return match.length > 0;
+}
+
+function locationFromHash(hash) {
+  if (hash == null) {
+    ({ hash } = window.location);
+  }
+  const s = hash.slice(1);
+  const v = s.split("/");
+  if (v.length !== 3) {
+    return { zoom: 2, latitude: 43, longitude: -89 };
+  }
+  const [zoom, latitude, longitude] = v.map((d) => parseFloat(d));
+
+  return { zoom, latitude, longitude };
+}
+
+function setWindowHash({ zoom, latitude, longitude }) {
+  const hashString = `${zoom}/${latitude}/${longitude}`;
+  window.location.hash = hashString;
+}
+
+export {
+  TopoJSONToLineString,
+  coordinatesAreEqual,
+  isOnOtherVertix,
+  distance_between_points,
+  locationFromHash,
+  setWindowHash,
+};

--- a/packages/column-footprint-editor/src/components/voronoi/help-dialog.tsx
+++ b/packages/column-footprint-editor/src/components/voronoi/help-dialog.tsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from "react";
+import { Dialog } from "@blueprintjs/core";
+import { MAP_MODES } from "../../context";
+
+interface VoronoiHelpDialogProps {
+  mode: MAP_MODES;
+}
+
+function VoronoiHelpDialog(props: VoronoiHelpDialogProps) {
+  const { mode } = props;
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (mode == MAP_MODES.voronoi) {
+      setOpen(true);
+    }
+  }, [mode]);
+
+  const onClose = () => setOpen(false);
+
+  return (
+    <Dialog isOpen={open} title="Tessellation Mode" onClose={onClose}>
+      <h1>Welcome to Tessellation Mode</h1>
+      <p>
+        You can add, move, and delete points to view tessellation. If two points
+        must added inside an existing polygon for tessellation to occur. Points
+        added outside of polygons will buffer to points; overlapping buffered
+        points will also tessellate.
+      </p>
+    </Dialog>
+  );
+}
+
+export { VoronoiHelpDialog };

--- a/packages/column-footprint-editor/src/components/voronoi/index.ts
+++ b/packages/column-footprint-editor/src/components/voronoi/index.ts
@@ -1,0 +1,2 @@
+export * from "./help-dialog";
+export * from "./tool-bar";

--- a/packages/column-footprint-editor/src/components/voronoi/tool-bar.tsx
+++ b/packages/column-footprint-editor/src/components/voronoi/tool-bar.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import {
+  Card,
+  Slider,
+  Callout,
+  Icon,
+} from "@blueprintjs/core";
+import { SyncAppActions, AsyncAppActions, MAP_MODES } from "../../context";
+
+// import { ReactComponent as FourSide } from "jsx:../../assets/4-side.svg";
+// import { ReactComponent as EightSide } from "jsx:../../assets/8-side.svg";
+// import { ReactComponent as TwelveSide } from "jsx:../../assets/12-side.svg";
+// import { ReactComponent as SixteenSide } from "jsx:../../assets/16-side.svg";
+// import { ReactComponent as TwentySide } from "jsx:../../assets/20-side.svg";
+// import { ReactComponent as TwentyFourSide } from "jsx:../../assets/24-side.svg";
+
+function HelpText() {
+  return (
+    <Callout intent="none">
+      <p>Options only for points picked outside of already existing polygon.</p>
+      <p>*distance measurements are not fully accurate.</p>
+    </Callout>
+  );
+}
+
+const shapeLabelRenderer = (val: number) => {
+  if (val == 1) {
+    return <Icon icon="symbol-diamond" />;
+  } else if (val == 6) {
+    return <Icon icon="symbol-circle" />;
+  }
+  return null;
+};
+
+interface VoronoiToolBarProps {
+  runAction(action: SyncAppActions | AsyncAppActions): Promise<void>;
+  quad_segs: number;
+  radius: number;
+  mode: MAP_MODES;
+}
+
+function VoronoiToolBar(props: VoronoiToolBarProps) {
+  if (props.mode != MAP_MODES.voronoi) return null;
+
+  const onChangeShape = (value: number) => {
+    /// runAction for shape setting
+    props.runAction({ type: "set-quad-seg", quad_seg: value });
+  };
+
+  const onChangeRadius = (value: number) => {
+    // change shape radius
+    props.runAction({ type: "set-radius", radius: value });
+  };
+
+  const style = {
+    position: "absolute",
+    top: "65px",
+    right: "50px",
+    background: "white",
+    zIndex: 1,
+  };
+  return (
+    <Card style={style}>
+      <Slider
+        min={0}
+        max={500}
+        stepSize={10}
+        showTrackFill={false}
+        value={props.radius}
+        onChange={onChangeRadius}
+        labelRenderer={(value) => `${value}km`}
+        labelValues={[1, 100, 200, 300, 400, 500]}
+      />
+      <Slider
+        min={1}
+        value={props.quad_segs}
+        max={6}
+        onChange={onChangeShape}
+        stepSize={1}
+        labelStepSize={1}
+        labelRenderer={shapeLabelRenderer}
+        showTrackFill={false}
+      />
+      <HelpText />
+    </Card>
+  );
+}
+
+export { VoronoiToolBar };

--- a/packages/column-footprint-editor/src/context/env.ts
+++ b/packages/column-footprint-editor/src/context/env.ts
@@ -1,0 +1,3 @@
+const base = process.env.API_BASE;
+const mapboxToken = process.env.MAPBOX_TOKEN;
+export { base, mapboxToken };

--- a/packages/column-footprint-editor/src/context/index.ts
+++ b/packages/column-footprint-editor/src/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./state";
+export * from "./env";

--- a/packages/column-footprint-editor/src/context/state/context.tsx
+++ b/packages/column-footprint-editor/src/context/state/context.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useReducer, useEffect } from "react";
+import { AppCtx, AppState, MAP_MODES } from "./types";
+import { appReducer, useAppContextActions } from "./reducer";
+
+let initialState: AppState = {
+  project: { project_id: null, name: null, description: null },
+  voronoi: { quad_seg: 2, radius: 100 },
+  lines: null,
+  points: null,
+  columns: null,
+  importOverlayOpen: true,
+  isSaving: false,
+  projectColumnGroups: null,
+  changeSet: [],
+  mode: MAP_MODES.properties,
+};
+
+const AppContext = createContext<AppCtx>({
+  state: initialState,
+  async runAction() {},
+  updateLinesAndColumns() {},
+});
+
+function AppContextProvider(props) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+  const runAction = useAppContextActions(dispatch);
+
+  function updateLinesAndColumns(project_id) {
+    runAction({ type: "fetch-geometries", project_id });
+  }
+
+  useEffect(() => {
+    if (state.project.project_id) {
+      updateLinesAndColumns(state.project.project_id);
+      let open = state.project.project_id == null;
+      runAction({ type: "import-overlay", payload: { open } });
+    }
+    return () => {};
+  }, [state.project.project_id]);
+
+  return (
+    <AppContext.Provider
+      value={{
+        state,
+        runAction,
+        updateLinesAndColumns,
+      }}
+    >
+      {props.children}
+    </AppContext.Provider>
+  );
+}
+
+export { AppContextProvider, AppContext };

--- a/packages/column-footprint-editor/src/context/state/fetch.tsx
+++ b/packages/column-footprint-editor/src/context/state/fetch.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import {
+  AppToaster,
+  SavingToast,
+  SuccessfullySaved,
+  BadSaving,
+} from "../../components/blueprint";
+import axios from "axios";
+import { base } from "../env";
+
+async function fetchColumns(project_id) {
+  let url = base + `${project_id}/columns`;
+  const res = await axios.get(url);
+
+  return res.data;
+}
+
+async function fetchLines(project_id) {
+  let url = base + `${project_id}/lines`;
+  const res = await axios.get(url);
+
+  return res.data;
+}
+
+async function fetchPoints(project_id) {
+  let url = base + `${project_id}/points`;
+  const res = await axios.get(url);
+  return res.data;
+}
+
+async function fetchProjColGroups(project_id) {
+  let url = base + `${project_id}/col-groups`;
+  const res = await axios.get(url);
+  return res.data.data;
+}
+
+async function fetchVoronoiPolygons(project_id, points, radius, quad_segs) {
+  let url = base + `${project_id}/voronoi`;
+  const res = await axios.put(url, { points, radius, quad_segs });
+  return res.data.polygons;
+}
+
+const saveLines = async (changeSet, project_id) => {
+  AppToaster.show({
+    message: <SavingToast />,
+    intent: "primary",
+    timeout: -1,
+  });
+  try {
+    let url = base + `${project_id}/lines`;
+    const res = await axios.put(url, {
+      change_set: changeSet,
+      project_id,
+    });
+    AppToaster.show({
+      message: <SuccessfullySaved />,
+      intent: "success",
+      timeout: 3000,
+    });
+  } catch (error) {
+    AppToaster.show({
+      message: <BadSaving />,
+      intent: "danger",
+      timeout: 5000,
+    });
+  }
+};
+
+const saveVoronoiPolygons = async (project_id, points, radius, quad_segs) => {
+  AppToaster.show({
+    message: <SavingToast message="Tessellating polygons..." />,
+    intent: "primary",
+    timeout: -1,
+  });
+  let url = base + `${project_id}/voronoi`;
+  const res = await axios.post(url, { points, radius, quad_segs });
+  if (res.status == 404) {
+    AppToaster.show({
+      message: <BadSaving />,
+      intent: "danger",
+      timeout: 5000,
+    });
+  } else {
+    AppToaster.show({
+      message: <SuccessfullySaved />,
+      intent: "success",
+      timeout: 3000,
+    });
+  }
+};
+
+export {
+  fetchColumns,
+  fetchLines,
+  fetchVoronoiPolygons,
+  fetchProjColGroups,
+  fetchPoints,
+  saveLines,
+  saveVoronoiPolygons,
+};

--- a/packages/column-footprint-editor/src/context/state/index.ts
+++ b/packages/column-footprint-editor/src/context/state/index.ts
@@ -1,0 +1,4 @@
+export * from "./context";
+export * from "./fetch";
+export * from "./types";
+export * from './reducer';

--- a/packages/column-footprint-editor/src/context/state/reducer.ts
+++ b/packages/column-footprint-editor/src/context/state/reducer.ts
@@ -1,0 +1,191 @@
+import { Dispatch } from "react";
+import { SyncAppActions, AppActions, AppState, MAP_MODES } from "./types";
+import {
+  fetchColumns,
+  fetchLines,
+  fetchPoints,
+  fetchVoronoiPolygons,
+  saveLines,
+  saveVoronoiPolygons,
+} from "./fetch";
+
+function useAppContextActions(dispatch: Dispatch<SyncAppActions>) {
+  return async (action: AppActions) => {
+    switch (action.type) {
+      case "fetch-geometries": {
+        const project_id = action.project_id;
+        const lines = await fetchLines(project_id);
+        const columns = await fetchColumns(project_id);
+        const points = await fetchPoints(project_id);
+        return dispatch({
+          type: "set-geometries",
+          data: { lines, columns, points },
+          mode: MAP_MODES.properties,
+        });
+      }
+      case "fetch-voronoi-state":
+        // should just take in points
+        const { project_id, points, point } = action;
+        if (points.length == 0) {
+          if (!point) {
+            return dispatch({
+              type: "set-voronoi-state",
+              polygons: [],
+              points: [],
+            });
+          }
+        }
+        let points_ = JSON.parse(JSON.stringify(points));
+        if (point) {
+          points_.push(point);
+        }
+        // this function should return polygons and points
+        const data = await fetchVoronoiPolygons(
+          project_id,
+          points_,
+          action.radius,
+          action.quad_segs
+        );
+        return dispatch({
+          type: "set-voronoi-state",
+          polygons: data,
+          points: [...points_],
+        });
+      case "save-changeset":
+        // save changeSet stuff
+        await saveLines(action.changeSet, action.project_id);
+        const lines_ = await fetchLines(action.project_id);
+        const columns_ = await fetchColumns(action.project_id);
+        const _points = await fetchPoints(action.project_id);
+        return dispatch({
+          type: "set-geometries",
+          data: { lines: lines_, columns: columns_, points: _points },
+          mode: MAP_MODES.topology,
+        });
+      case "save-voronoi":
+        await saveVoronoiPolygons(
+          action.project_id,
+          action.voronoiState.points,
+          action.voronoiState.radius,
+          action.voronoiState.quad_seg
+        );
+        const _lines_ = await fetchLines(action.project_id);
+        const _columns_ = await fetchColumns(action.project_id);
+        const _points_ = await fetchPoints(action.project_id);
+        return dispatch({
+          type: "set-geometries",
+          data: { lines: _lines_, columns: _columns_, points: _points_ },
+          mode: MAP_MODES.topology,
+        });
+      default:
+        return dispatch(action);
+    }
+  };
+}
+
+const appReducer = (state: AppState, action: SyncAppActions) => {
+  switch (action.type) {
+    case "change-project":
+      return {
+        ...state,
+        project: action.payload,
+      };
+    case "set-geometries":
+      return {
+        ...state,
+        columns: action.data.columns,
+        lines: action.data.lines,
+        points: action.data.points,
+        changeSet: [],
+        voronoi: { ...state.voronoi, polygons: [], points: [] },
+        mode: action.mode,
+      };
+    case "import-overlay":
+      return {
+        ...state,
+        importOverlayOpen: action.payload.open,
+      };
+    case "is-saving":
+      return {
+        ...state,
+        isSaving: action.payload.isSaving,
+      };
+    case "add-voronoi-points":
+      const curVoronoiPoints = state.voronoi.points ?? [];
+      const newVoronoiPoints = [...curVoronoiPoints, action.point];
+      return {
+        ...state,
+        voronoi: {
+          ...state.voronoi,
+          points: newVoronoiPoints,
+        },
+      };
+    case "set-voronoi-state":
+      return {
+        ...state,
+        voronoi: {
+          ...state.voronoi,
+          polygons: action.polygons,
+          points: action.points,
+        },
+      };
+    case "change-voronoi-point":
+      const currentPoints = state.voronoi.points ?? [];
+      if (currentPoints.length > 0) {
+        let idx;
+        currentPoints.map((p, i) => {
+          if (p.id == action.point.id) {
+            idx = i;
+          }
+        });
+        const points = JSON.parse(JSON.stringify(currentPoints));
+        points.splice(idx, 1, action.point);
+        return {
+          ...state,
+          voronoi: {
+            ...state.voronoi,
+            points,
+          },
+        };
+      }
+      return {
+        ...state,
+        voronoi: {
+          ...state.voronoi,
+          points: [action.point],
+        },
+      };
+    case "set-quad-seg":
+      return {
+        ...state,
+        voronoi: {
+          ...state.voronoi,
+          quad_seg: action.quad_seg,
+        },
+      };
+    case "set-radius":
+      return {
+        ...state,
+        voronoi: {
+          ...state.voronoi,
+          radius: action.radius,
+        },
+      };
+    case "add-to-changeset":
+      return {
+        ...state,
+        changeSet: [...state.changeSet, action.item],
+      };
+    case "clear-changeset":
+      return {
+        ...state,
+        changeSet: [],
+      };
+    case "set-map-mode":
+      return { ...state, mode: action.mode };
+    default:
+      throw new Error("What does this mean?");
+  }
+};
+
+export { appReducer, useAppContextActions };

--- a/packages/column-footprint-editor/src/context/state/types.ts
+++ b/packages/column-footprint-editor/src/context/state/types.ts
@@ -1,0 +1,141 @@
+//////////////////////// Data Types ///////////////////////
+
+type ProjectId = { project_id: number };
+type ProjectName = { name: string };
+type ProjectDescription = { description: string };
+type Columns = { columns: object };
+type Lines = { lines: object };
+type Points = { points: object };
+type Project = ProjectId & ProjectName & ProjectDescription;
+type VoronoiPoint = {
+  type: "Feature";
+  id: string;
+  geometry: { coordinates: [number, number]; type: "Point" };
+};
+type VoronoiPoints = VoronoiPoint[];
+type ChangeSetItem = {
+  action: ChangeSetAction;
+  feature: {
+    type: "Feature";
+    id: string;
+    properties: { id: number }; // id of line in database
+    geometry: { coordinates: [number[]]; type: "MultiLineString" };
+  };
+};
+enum ChangeSetAction {
+  DRAW_CREATE = "draw.create",
+  DRAW_DELETE = "draw.delete",
+  CHANGE_COORDINATE = "change_coordinates",
+}
+export enum MAP_MODES {
+  topology,
+  properties,
+  voronoi,
+}
+/////////////////////// Async Actions ///////////////////////
+type FetchGeometries = { type: "fetch-geometries"; project_id: number };
+type FetchVoronoiState = {
+  type: "fetch-voronoi-state";
+  points: VoronoiPoints;
+  point: any;
+  project_id: number;
+  radius: number;
+  quad_segs: number;
+};
+type SaveChangeSet = {
+  type: "save-changeset";
+  changeSet: ChangeSetItem[];
+  project_id: number;
+};
+
+type SaveVoronoi = {
+  type: "save-voronoi";
+  project_id: number;
+  voronoiState: VoronoiState;
+};
+////////////////////// Sync Actions ///////////////////////////
+
+type ChangeProject = { type: "change-project"; payload: Project };
+type ImportOverlay = { type: "import-overlay"; payload: { open: boolean } };
+type IsSaving = { type: "is-saving"; payload: { isSaving: boolean } };
+type SetGeometries = {
+  type: "set-geometries";
+  data: Columns & Lines & Points;
+  mode: MAP_MODES;
+};
+type AddVoronoiPoints = { type: "add-voronoi-points"; point: VoronoiPoint };
+type ChangeVoronoiPoint = { type: "change-voronoi-point"; point: VoronoiPoint };
+type SetVoronoiState = {
+  type: "set-voronoi-state";
+  polygons: any;
+  points: any;
+};
+type SetQuadSeg = { type: "set-quad-seg"; quad_seg: number };
+type SetRadius = { type: "set-radius"; radius: number };
+type SetMapMode = { type: "set-map-mode"; mode: MAP_MODES };
+type AddToChangeSet = { type: "add-to-changeset"; item: ChangeSetItem };
+type ClearChangeSet = { type: "clear-changeset" };
+
+////////////////////// Union Action Types //////////////////////
+export type SyncAppActions =
+  | AddToChangeSet
+  | SetMapMode
+  | SetRadius
+  | SetQuadSeg
+  | ChangeProject
+  | ImportOverlay
+  | IsSaving
+  | AddVoronoiPoints
+  | SetVoronoiState
+  | ChangeVoronoiPoint
+  | SetGeometries
+  | ClearChangeSet;
+
+export type AsyncAppActions =
+  | FetchGeometries
+  | FetchVoronoiState
+  | SaveChangeSet
+  | SaveVoronoi;
+
+export type AppActions = SyncAppActions | AsyncAppActions;
+
+interface ProjectInterface {
+  project_id: number | null;
+  name: string | null;
+  description: string | null;
+}
+
+interface VoronoiState {
+  points?: VoronoiPoints;
+  polygons?: any;
+  quad_seg: number;
+  radius: number;
+}
+
+interface AppState {
+  project: ProjectInterface;
+  voronoi: VoronoiState;
+  lines: object | null;
+  points: object | null;
+  columns: object | null;
+  importOverlayOpen: boolean;
+  isSaving: boolean;
+  projectColumnGroups: object[] | null;
+  changeSet: ChangeSetItem[];
+  mode: MAP_MODES;
+}
+
+interface AppCtx {
+  state: AppState;
+  runAction(action: AppActions): Promise<void>;
+  updateLinesAndColumns: (e) => void;
+}
+
+export {
+  AppCtx,
+  AppState,
+  VoronoiState,
+  ProjectInterface,
+  VoronoiPoint,
+  ChangeSetItem,
+};

--- a/packages/column-footprint-editor/src/index.html
+++ b/packages/column-footprint-editor/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Column Topology</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/packages/column-footprint-editor/src/index.tsx
+++ b/packages/column-footprint-editor/src/index.tsx
@@ -1,0 +1,17 @@
+import "regenerator-runtime/runtime";
+import React from "react";
+import { render } from "react-dom";
+import { AppContextProvider } from "./context";
+import { Map } from "./components";
+
+function App() {
+  return (
+    <AppContextProvider>
+      <div>
+        <Map />
+      </div>
+    </AppContextProvider>
+  );
+}
+
+render(<App />, document.getElementById("root"));


### PR DESCRIPTION
- **first commit**
- **shared verticies will snap on drag. Fixed in same feature bug and triple junction bug**
- **found more bugs. A short-term solution is at draw.update I've just reverted to mult_vert mode**
- **verticies change together onDrag**
- **increase performance, lose granularity**
- **postgis-geo-map as submodule**
- **db persistence, WIP: creating new polys. My helper function sucks still**
- **fixes clicking within feature and other feature, code simplified, distance between points functions decides which points to drag, function of pixel distance**
- **custom draw modes are now isolated in separate files**
- **custom draw modes are now isolated in separate files**
- **deleted voroni stuff, created a view that joins map-faces on identity polygons and have geojson endpoint for it**
- **blueprintjs components used for navbar and overlay**
- **property view mode init commit**
- **enhanced frontend design and editing capabilities**
- **blueprint components for spruced up frontend**
- **download geojson button**
- **Importer class and API with frontend exposure if nothing in DB**
- **WIP frontend: polygon on click, backend: config style project differentiation for schemas and topologies**
- **WIP, break map useEffect into smaller pieces. Larger state management**
- **WIP**
- **major changes**
- **New project creation is now possible through frontend and supported on the backend, async and sync reducer actions now more robust in frontend code. Backend classes have new methods for creating a new project**
- **bugs and WIP column-groups**
- **Col groups meta table. Foreign key in project_schema.columns. Color coded col_groups on properties view.**
- **Col group can be added to column, a new col group can be created and added to a col**
- **Feature updates; can add known geometry via WKT or GeoJSON**
- **begin simplifcation**
- **code refactored**
- **begin dockerization; column-groups are project specific, download as csv**
- **dockerized application**
- **docker ports and api base env variables**
- **docker now runs frontend production and runs an npx static server**
- **simplified environment variables**
- **changelog, one char change for moving connected points in same polygon-line; removed some consoling**
- **multiline-string works for draggin, line tool not working yet**
- **snapping tool with multilinestring; now snapping to a point on the line creates a new coordinate**
- **snapping changed back to relative pixel distance instead of absolute distance**
- **toolbar is fixed to top and map is completely visible**
- **Properties Modal is now draggable**
- **Properties Modal is now draggable**
- **Properties Modal is now draggable**
- **Properties Modal is now draggable**
- **map is set under navbar**
- **turf function randomly began returning Infinity and breaking everything**
- **some quality of life UI enhancements**
- **more streamlined home panel; panelstack and about page panel**
- **project btn spacing**
- **removed unused import**
- **create n-sided polygon that expands on mousemove**
- **hold shift on vertix click to prevent dragging**
- **increased click buffer**
- **removed unused**
- **WIP reseting info overlay after post/put**
- **columns have a description field and column-groups can have specified colors chosen by a color-picker**
- **proper attribution**
- **WIP, property dialog shows updated info on save. But can't be edited again..**
- **Edited properties visible on save, polygon stays highlighted and it can be edited again right away**
- **work off of postgrest API**
- **import points as well, have option for no column geometries**
- **wip voronoi mode**
- **Voronoi tesselation**
- **map event handlers for drawing**
- **handling point state**
- **nav-bar aware of some state**
- **nav-bar aware of some state**
- **wip**
- **remove onclick refiring**
- **more straightforward points only approach**
- **more straightforward points only approach**
- **database persistence for voronoi**
- **WIP trying to get SVGs to work**
- **upgraded parcel**
- **WIP make buffer radius and quad_seg dynamci**
- **remove map event listeners; radius and quad_seqs in state**
- **clean up console logging**
- **figuring out col-group-ids**
- **development port change**
- **remove unused console logs**
- **remove options event listner**
- **removed console log**
- **mapbox token to env**
- **major rework of state flow**
- **larger start radius**
- **more radius choices**
- **proper way to copy modes**
- **correct order of mode object assignment**
- **help text**
- **unused imports**
- **simplyfy**
- **points only expoty**
- **blueprint menu**
- **frontend clean ups**
- **saving toasters shouldn't timeout until complete**
- **only accept wkt**
- **addGeom needs to update based on draw.ref**
- **frontend clean ups**
- **moved exmaple .env**
- **needed to get it to build**
- **Some small edits to dependency files**
