### PR TITLE
Expired session handling & silent refresh

### DIFF
--- a/packages/settings/index.ts
+++ b/packages/settings/index.ts
@@ -51,6 +51,12 @@ export const ingestPrefix = getRuntimeConfig(
   apiV3Prefix
 );
 
+//update to /auth down the road in v3
+export const authPrefix = getRuntimeConfig(
+  "MACROSTRAT_AUTH_API",
+  apiV3Prefix + "/security"
+);
+
 export const webAssetsPrefix = getRuntimeConfig(
   "MACROSTRAT_WEB_ASSETS_PREFIX",
   "https://storage.macrostrat.org/assets/web"

--- a/pages/+Layout.ts
+++ b/pages/+Layout.ts
@@ -1,7 +1,7 @@
 import { DarkModeProvider } from "@macrostrat/ui-components";
 import { ReactNode } from "react";
 
-import { AuthProvider, AuthRefreshGate } from "~/_providers/auth";
+import { AuthProvider } from "~/_providers/auth";
 import { usePageContext } from "vike-react/usePageContext";
 import { pageLayouts } from "~/layouts";
 
@@ -21,11 +21,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 
   return h(
     AuthProvider,
-    { user }, // Prefer detailed user if available
-    h(
-      AuthRefreshGate,
-      { canRefresh },
-      h(DarkModeProvider, { followSystem: true }, h(layout, children))
-    )
+    { user, canRefresh }, // Prefer detailed user if available
+    h(DarkModeProvider, { followSystem: true }, h(layout, children))
   );
 }

--- a/pages/+Layout.ts
+++ b/pages/+Layout.ts
@@ -1,7 +1,7 @@
 import { DarkModeProvider } from "@macrostrat/ui-components";
 import { ReactNode } from "react";
 
-import { AuthProvider } from "~/_providers/auth";
+import { AuthProvider, AuthRefreshGate } from "~/_providers/auth";
 import { usePageContext } from "vike-react/usePageContext";
 import { pageLayouts } from "~/layouts";
 
@@ -12,7 +12,7 @@ import h from "@macrostrat/hyper";
 
 export default function Layout({ children }: { children: ReactNode }) {
   const pageContext = usePageContext();
-  const { exports = {}, config, user } = pageContext;
+  const { exports = {}, config, user, canRefresh } = pageContext;
   const pageBreadcrumbs = pageContext.exports.pageBreadcrumbs;
 
   const pageStyle = exports?.pageStyle ?? "content2";
@@ -22,6 +22,10 @@ export default function Layout({ children }: { children: ReactNode }) {
   return h(
     AuthProvider,
     { user }, // Prefer detailed user if available
-    h(DarkModeProvider, { followSystem: true }, h(layout, children))
+    h(
+      AuthRefreshGate,
+      { canRefresh },
+      h(DarkModeProvider, { followSystem: true }, h(layout, children))
+    )
   );
 }

--- a/pages/+config.ts
+++ b/pages/+config.ts
@@ -24,6 +24,7 @@ export default {
     "supportsDarkMode",
     "routeParams",
     "user",
+    "canRefresh",
     "description",
     "title",
     "environment",

--- a/pages/+onCreatePageContext.server.ts
+++ b/pages/+onCreatePageContext.server.ts
@@ -8,6 +8,11 @@ export async function onCreatePageContext(pageContext: PageContextServer) {
 
   const cookies = getCookies(pageContext.headers);
   pageContext.user = await getUserFromCookie(cookies);
+  // If we couldn't establish a user but a refresh token is still present, the
+  // access token has expired (or was dropped by the browser at Max-Age) — signal
+  // the client to attempt one silent refresh on load.
+  pageContext.canRefresh =
+    pageContext.user == null && cookies?.["refresh_token"] != null;
   return pageContext;
 }
 

--- a/src/_providers/auth.ts
+++ b/src/_providers/auth.ts
@@ -4,6 +4,7 @@ import {
   AsyncAuthAction,
 } from "@macrostrat/form-components";
 import h from "@macrostrat/hyper";
+import { Fragment, ReactNode, useEffect, useRef } from "react";
 import { ingestPrefix } from "../../packages/settings";
 import { isLocalTesting, mockUser } from "./localTestingAuth";
 
@@ -55,6 +56,73 @@ export function AuthProvider(props) {
       return h("code", JSON.stringify(user));
     },
   });
+}
+
+/**
+ * Silently mint a new access token from the refresh-token cookie. The browser
+ * sends the refresh cookie and stores the new access cookie for us.
+ */
+async function refreshSession(): Promise<boolean> {
+  if (isLocalTesting()) return false;
+  try {
+    const response = await fetch(`${ingestPrefix}/security/refresh`, {
+      method: "POST",
+      credentials: "include",
+    });
+    return response.ok;
+  } catch (error) {
+    return false;
+  }
+}
+
+// One-shot guard (survives the reload below) so a refresh that doesn't actually
+// restore a usable cookie can't cause a reload loop. Reset on any healthy load.
+const REFRESH_RELOAD_FLAG = "ms-auth-refresh-reloaded";
+
+/**
+ * When the server signals `canRefresh` (access token expired but a refresh
+ * token is still present), silently refresh on load and, on success, do a full
+ * reload.
+ *
+ * The reload — rather than an in-place `get-status` — is deliberate: only a
+ * reload re-runs SSR and re-issues *every* client fetch (the auth UI AND
+ * client-side PostgREST queries like `rpc/auth_status`) WITH the fresh cookie.
+ * An in-place update can't re-run PostgREST queries that already fired on mount
+ * without a cookie, so they'd stay stuck on `web_anon`.
+ */
+export function useReactiveAuthRefresh(canRefresh: boolean) {
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    if (!canRefresh) {
+      // Healthy or anonymous load — clear the guard so a later expiry can refresh.
+      sessionStorage.removeItem(REFRESH_RELOAD_FLAG);
+      return;
+    }
+    // Already attempted this tab session: don't reload-loop if the refresh
+    // didn't yield a usable cookie.
+    if (sessionStorage.getItem(REFRESH_RELOAD_FLAG)) return;
+    sessionStorage.setItem(REFRESH_RELOAD_FLAG, "1");
+
+    refreshSession().then((ok) => {
+      if (ok) window.location.reload();
+    });
+  }, [canRefresh]);
+}
+
+/** Runs the reactive refresh; must render inside AuthProvider. */
+export function AuthRefreshGate({
+  canRefresh = false,
+  children,
+}: {
+  canRefresh?: boolean;
+  children: ReactNode;
+}) {
+  useReactiveAuthRefresh(canRefresh);
+  return h(Fragment, null, children);
 }
 
 export async function fetchUser() {

--- a/src/_providers/auth.ts
+++ b/src/_providers/auth.ts
@@ -4,9 +4,11 @@ import {
   AsyncAuthAction,
 } from "@macrostrat/form-components";
 import h from "@macrostrat/hyper";
-import { Fragment, ReactNode, useEffect, useRef } from "react";
-import { ingestPrefix } from "../../packages/settings";
+import { useEffect, useRef } from "react";
+import { authPrefix } from "../../packages/settings";
 import { isLocalTesting, mockUser } from "./localTestingAuth";
+import { reload } from 'vike/client/router'
+
 
 async function authTransformer(
   action: AuthAction | AsyncAuthAction
@@ -27,11 +29,11 @@ async function authTransformer(
       // Assemble the return URL on click based on the current page
       const return_url = window.location.origin + window.location.pathname;
       console.log("Returning to", return_url);
-      window.location.href = `${ingestPrefix}/security/login?return_url=${return_url}`;
+      window.location.href = `${authPrefix}/login?return_url=${return_url}`;
     case "logout":
       // Delete the token from the session
       try {
-        const response = await fetch(`${ingestPrefix}/security/logout`, {
+        const response = await fetch(`${authPrefix}/logout`, {
           method: "POST",
           credentials: "include",
         });
@@ -48,7 +50,15 @@ async function authTransformer(
   }
 }
 
-export function AuthProvider(props) {
+export function AuthProvider({
+  canRefresh = false,
+  ...props
+}: {
+  canRefresh?: boolean;
+  [key: string]: any;
+}) {
+  // Silently re-authenticate on load when the server says a refresh is possible.
+  useReactiveAuthRefresh(canRefresh);
   return h(BaseAuthProvider, {
     ...props,
     transformer: authTransformer,
@@ -65,7 +75,7 @@ export function AuthProvider(props) {
 async function refreshSession(): Promise<boolean> {
   if (isLocalTesting()) return false;
   try {
-    const response = await fetch(`${ingestPrefix}/security/refresh`, {
+    const response = await fetch(`${authPrefix}/refresh`, {
       method: "POST",
       credentials: "include",
     });
@@ -113,21 +123,9 @@ export function useReactiveAuthRefresh(canRefresh: boolean) {
   }, [canRefresh]);
 }
 
-/** Runs the reactive refresh; must render inside AuthProvider. */
-export function AuthRefreshGate({
-  canRefresh = false,
-  children,
-}: {
-  canRefresh?: boolean;
-  children: ReactNode;
-}) {
-  useReactiveAuthRefresh(canRefresh);
-  return h(Fragment, null, children);
-}
-
 export async function fetchUser() {
   if (isLocalTesting()) return mockUser;
-  const response = await fetch(`${ingestPrefix}/security/me`, {
+  const response = await fetch(`${authPrefix}/me`, {
     method: "GET",
     credentials: "include",
   });

--- a/src/vike.d.ts
+++ b/src/vike.d.ts
@@ -42,6 +42,9 @@ declare global {
       pageInfo?: PageInfo;
       urlPathname: string;
       user?: User;
+      // Set server-side: access token gone/expired but a refresh token is
+      // present, so the client should attempt one silent refresh on load.
+      canRefresh?: boolean;
       breadcrumbs?: Item[];
       macrostratLogoFlavor?: string;
       mdxContent?: string;


### PR DESCRIPTION
### Workflow:
---
- On login, `api-v3` sets the `access_token ` cookie (24h) with a `Max-Age` that matches the JWT's `exp`, plus a `refresh_token` cookie (7d).
- When the access token expires, the browser automatically drops the cookie (because `Max-Age` elapsed), so the next request carries no access cookie.
- Caddy bridges on cookie presence: no cookie → no Authorization header → PostgREST returns `web_anon` (public data, no error). PostgREST still strictly rejects any token that does arrive expired with a `401` `unauthorized`.
- On a full page load, the vike web SSR decodes the cookie; if there's no valid user but a `refresh_token` cookie is present, it sets `pageContext.canRefresh = true`.
- The client reads `canRefresh` (globally, in the root layout) and, if true, sends one `POST /security/refresh`. The browser attaches the refresh cookie; `api-v3 `validates it and sets a fresh `access_token` cookie.
- On success, the client does a full reload, so SSR and every client-side fetch (including PostgREST queries) re-run with the new cookie — the user is silently logged back in.
- Otherwise it stays anonymous: a failed refresh (dead refresh token) or a genuine anonymous visitor (no refresh cookie → `canRefresh` false) fires no request.

Tied to [api-v3 PR.](https://github.com/UW-Macrostrat/macrostrat/pull/301)