### PR TITLE
delegated token works for emit-minerals page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ VITE_MACROSTRAT_API_DOMAIN='https://macrostrat.org'
 # VITE_MACROSTRAT_INGEST_API=https://dev.macrostrat.org/api/ingest
 # SECRET_KEY='Replace with api signing key'
 
+# Needed for the EMIT mineral maps page (/dev/map/emit-mineral-maps).
+# The tileserver's rasters/emit-minerals routes require a delegated token; mint
+# one with `macrostrat auth create-token --label MACROSTRAT_EMIT_MINERALS_TOKEN
+# --scope rasters:emit-minerals --days 730`. Public by design, like a Mapbox
+# pk.* token — it reaches the browser, and its value is that it can be revoked.
+# VITE_MACROSTRAT_EMIT_MINERALS_TOKEN='<delegated token>'
+
 # Needed for legacy map comparisons
 # VITE_MACROSTRAT_TILESERVER_V2='https://dev.macrostrat.org/tiles'
 # VITE_MACROSTRAT_TILESERVER_V1='https://tiles.macrostrat.org'

--- a/packages/settings/index.ts
+++ b/packages/settings/index.ts
@@ -23,6 +23,20 @@ export const pbdbDomain = "https://paleobiodb.org";
 
 export const mapboxAccessToken = getRuntimeConfig("MAPBOX_API_TOKEN");
 
+/** Delegated token for the guarded `rasters/emit-minerals` tileserver routes.
+ *
+ * Public by design, in the same way a Mapbox `pk.*` token is: it reaches the
+ * browser via `window.env`, so anyone can read it from the page. Its value is
+ * that it identifies our app as the consumer and can be revoked without a code
+ * change (`macrostrat auth revoke-token`, or the /dev/me page) — not that it is
+ * secret.
+ *
+ * Long-lived (~2 years) so the page keeps working; third parties get their own
+ * shorter-lived tokens for using the API directly. */
+export const emitMineralsToken = getRuntimeConfig(
+  "MACROSTRAT_EMIT_MINERALS_TOKEN"
+);
+
 export const baseURL = getRuntimeConfig("BASE_URL", "/");
 
 export const apiV2Prefix = getRuntimeConfig(

--- a/pages/+onCreatePageContext.server.ts
+++ b/pages/+onCreatePageContext.server.ts
@@ -38,10 +38,6 @@ export async function onCreatePageContext(pageContext: PageContextServer) {
   return pageContext;
 }
 
-
-//TODO hash api key using SECRET here. scopes: rasters/emit-minerals/, label: MACROSTRAT_EMITMIN_KEY
-//have web_admins create token on dev/me page (verify jwt), revoke
-
 // --- GeoIP ------------------------------------------------------------------
 
 // The reader is opened once per server process and reused (mmap-backed, fast).

--- a/pages/+onCreatePageContext.server.ts
+++ b/pages/+onCreatePageContext.server.ts
@@ -38,6 +38,10 @@ export async function onCreatePageContext(pageContext: PageContextServer) {
   return pageContext;
 }
 
+
+//TODO hash api key using SECRET here. scopes: rasters/emit-minerals/, label: MACROSTRAT_EMITMIN_KEY
+//have web_admins create token on dev/me page (verify jwt), revoke
+
 // --- GeoIP ------------------------------------------------------------------
 
 // The reader is opened once per server process and reused (mmap-backed, fast).

--- a/pages/dev/map/emit-mineral-maps/+Page.client.ts
+++ b/pages/dev/map/emit-mineral-maps/+Page.client.ts
@@ -98,11 +98,9 @@ const mosaicBaseURL = `${burwellTileDomain}/rasters/${RASTER_LAYER}`;
  *
  * `/cog` is not guarded, so `cogBaseURL` requests use plain `fetch`. */
 function mosaicFetch(url: string, init: RequestInit = {}) {
-  const headers: Record<string, string> = {
-    ...((init.headers as Record<string, string>) ?? {}),
-  };
+  const headers = new Headers(init.headers);
   if (emitMineralsToken) {
-    headers.Authorization = `Bearer ${emitMineralsToken}`;
+    headers.set("Authorization", `Bearer ${emitMineralsToken}`);
   }
   return fetch(url, { ...init, headers });
 }
@@ -159,10 +157,13 @@ export function Page() {
   // Mapbox fetches the raster tiles and the footprints MVT itself, so the
   // delegated token has to be attached here rather than at a call site. Scoped
   // to this layer's prefix so no token is sent to any other tileserver route.
-  const transformRequest = useCallback((url: string) => {
+const transformRequest = useCallback(
+  (url: string) => {
     if (!emitMineralsToken || !url.startsWith(mosaicBaseURL)) return { url };
     return { url, headers: { Authorization: `Bearer ${emitMineralsToken}` } };
-  }, []);
+  },
+  [emitMineralsToken]
+);
 
   let detailPanel = null;
   if (inspectPosition != null) {

--- a/pages/dev/map/emit-mineral-maps/+Page.client.ts
+++ b/pages/dev/map/emit-mineral-maps/+Page.client.ts
@@ -26,7 +26,11 @@
  */
 
 import hyper from "@macrostrat/hyper";
-import { burwellTileDomain, mapboxAccessToken } from "@macrostrat-web/settings";
+import {
+  burwellTileDomain,
+  emitMineralsToken,
+  mapboxAccessToken,
+} from "@macrostrat-web/settings";
 import { Box, useDarkMode } from "@macrostrat/ui-components";
 import { Tag as ClassTag, TagSize } from "@macrostrat/data-components";
 import { removeMapLabels, type MapPosition } from "@macrostrat/mapbox-utils";
@@ -87,6 +91,22 @@ const FOOTPRINTS_SOURCE_LAYER = "raster_footprints";
 const cogBaseURL = `${burwellTileDomain}/cog`;
 const mosaicBaseURL = `${burwellTileDomain}/rasters/${RASTER_LAYER}`;
 
+/** Every route under `/rasters/emit-minerals` requires a delegated token — the
+ * tiles, but also `/layer`, `/footprints` and `/point`. So the token goes on
+ * this layer's own requests, in a header rather than the query string (a tile
+ * URL ends up in access logs, history and `Referer`).
+ *
+ * `/cog` is not guarded, so `cogBaseURL` requests use plain `fetch`. */
+function mosaicFetch(url: string, init: RequestInit = {}) {
+  const headers: Record<string, string> = {
+    ...((init.headers as Record<string, string>) ?? {}),
+  };
+  if (emitMineralsToken) {
+    headers.Authorization = `Bearer ${emitMineralsToken}`;
+  }
+  return fetch(url, { ...init, headers });
+}
+
 /** Fallback view: the conterminous US, where most of the datasets sit. */
 const DEFAULT_BOUNDS = [-125, 24, -66, 49];
 
@@ -136,6 +156,14 @@ export function Page() {
     [showLabels]
   );
 
+  // Mapbox fetches the raster tiles and the footprints MVT itself, so the
+  // delegated token has to be attached here rather than at a call site. Scoped
+  // to this layer's prefix so no token is sent to any other tileserver route.
+  const transformRequest = useCallback((url: string) => {
+    if (!emitMineralsToken || !url.startsWith(mosaicBaseURL)) return { url };
+    return { url, headers: { Authorization: `Bearer ${emitMineralsToken}` } };
+  }, []);
+
   let detailPanel = null;
   if (inspectPosition != null) {
     detailPanel = h(
@@ -170,6 +198,7 @@ export function Page() {
         style: baseStyle,
         overlayStyles,
         transformStyle,
+        transformRequest,
         mapPosition,
         onMapMoved,
         projection: { name: "globe" },
@@ -311,7 +340,7 @@ function round5(value: number): number {
  * a single request that reads no pixels — no reference COG, and no parsing GDAL
  * metadata in the browser. */
 const mosaicLayerAtom = atom(async (get, { signal }) => {
-  const response = await fetch(`${mosaicBaseURL}/layer`, { signal });
+  const response = await mosaicFetch(`${mosaicBaseURL}/layer`, { signal });
   if (!response.ok) {
     throw new Error(`Failed to fetch layer metadata: ${response.statusText}`);
   }
@@ -358,7 +387,7 @@ const layerInfoLoadableAtom = loadable(layerInfoAtom);
  * FeatureCollection means the index has no rasters for this layer, which is the
  * expected state until they're added. */
 const footprintsAtom = atom(async (get, { signal }) => {
-  const response = await fetch(`${mosaicBaseURL}/footprints`, { signal });
+  const response = await mosaicFetch(`${mosaicBaseURL}/footprints`, { signal });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch mosaic footprints: ${response.statusText}`
@@ -390,7 +419,7 @@ const pointDataAtom = atom(async (get, { signal }) => {
   // map is showing one raster. The focused one is marked in the panel instead.
   const url = `${mosaicBaseURL}/point/${lng},${lat}`;
 
-  const response = await fetch(url, { signal });
+  const response = await mosaicFetch(url, { signal });
   // Outside coverage the mosaic answers 204 with no body, so this has to be
   // checked before parsing — `json()` on an empty body throws.
   if (response.status === 204) return { assets: [] };


### PR DESCRIPTION
The emit-minerals page now passes a token `VITE_MACROSTRAT_EMIT_MINERALS_TOKEN` as a Bearer header to the emit-minerals api endpoints. 

TODO:
- create auth token for development (via the new `macrostrat auth create-token` command from https://github.com/UW-Macrostrat/macrostrat/pull/315)
- seal and save in kubernetes config.
- redeploy container 

